### PR TITLE
142 functionally create and delete persons in a world unit by checking when giftunits are saved

### DIFF
--- a/src/agenda/agenda.py
+++ b/src/agenda/agenda.py
@@ -906,7 +906,7 @@ class AgendaUnit:
         # Now get associates (all their descendants and range_source_roads)
         lemma_beliefunits = {}  # belief.base : beliefUnit
         count_x = 0
-        while (count_x > 10000 or x_lemmas.is_lemmas_evaluated()) is False:
+        while count_x < 10000 and x_lemmas.is_lemmas_evaluated() is False:
             count_x += 1
             if count_x == 9998:
                 raise InvalidAgendaException("lemma loop failed")

--- a/src/agenda/agenda.py
+++ b/src/agenda/agenda.py
@@ -1116,6 +1116,11 @@ class AgendaUnit:
         bundling: bool = True,
         create_missing_ancestors: bool = True,
     ):
+        if RoadNode(idea_kid._label).is_node(self._road_delimiter) == False:
+            raise InvalidAgendaException(
+                f"add_idea failed because '{idea_kid._label}' is not a RoadNode."
+            )
+
         if self._idearoot._label != get_root_node_from_road(
             parent_road, self._road_delimiter
         ):
@@ -1519,6 +1524,11 @@ class AgendaUnit:
             for x_idea in self._idea_dict.values()
             if x_idea.is_intent_item(necessary_base=base)
         }
+
+    def get_all_pledges(self) -> dict[RoadUnit:IdeaUnit]:
+        self.calc_agenda_metrics()
+        all_ideas = self._idea_dict.values()
+        return {x_idea.get_road(): x_idea for x_idea in all_ideas if x_idea.pledge}
 
     def set_intent_task_complete(self, task_road: RoadUnit, base: RoadUnit):
         pledge_item = self.get_idea_obj(task_road)

--- a/src/agenda/test_agenda/test_agenda_calc_metrics.py
+++ b/src/agenda/test_agenda/test_agenda_calc_metrics.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from src._road.road import RoadUnit
-from src.agenda.agenda import agendaunit_shop, get_from_json
+from src.agenda.agenda import agendaunit_shop, get_from_json as agendaunit_get_from_json
 from src.agenda.idea import IdeaUnit, ideaunit_shop
 from src.agenda.reason_idea import reasonunit_shop
 from src.agenda.group import groupunit_shop, balancelink_shop
@@ -17,7 +17,7 @@ from src.agenda.examples.example_agendas import (
 )
 
 
-def test_get_intent_dict_ReturnsCorrectObj():
+def test_AgendaUnit_get_intent_dict_ReturnsCorrectObj():
     # GIVEN
     bob_agenda = example_agendas_get_agenda_with_4_levels()
 
@@ -32,7 +32,7 @@ def test_get_intent_dict_ReturnsCorrectObj():
     assert bob_agenda.make_l1_road("feed cat") in intent_dict.keys()
 
 
-def test_agenda_get_intent_dict_ReturnsIntentWithOnlyCorrectItems():
+def test_AgendaUnit_get_intent_dict_ReturnsIntentWithOnlyCorrectItems():
     # GIVEN
     x_agenda = example_agendas_get_agenda_with_4_levels_and_2reasons()
     week_text = "weekdays"
@@ -55,7 +55,7 @@ def test_agenda_get_intent_dict_ReturnsIntentWithOnlyCorrectItems():
     assert x_agenda.make_l1_road("feed cat") in intent_dict.keys()
 
 
-def test_get_intent_returns_intent_WithAgendaImportance():
+def test_AgendaUnit_get_intent_dict_WithLargeAgendaImportance():
     # GIVEN
     x_agenda = example_agendas_get_agenda_with_4_levels_and_2reasons_2beliefs()
 
@@ -73,7 +73,7 @@ def test_get_intent_returns_intent_WithAgendaImportance():
     assert intent_dict.get(x_agenda.make_l1_road(casa_text))._agenda_importance
 
 
-def test_get_intent_with_No7amItem():
+def test_AgendaUnit_get_intent_WithNo7amItemExample():
     # GIVEN
     x_agenda = example_agendas_get_agenda_with7amCleanTableReason()
 
@@ -93,7 +93,7 @@ def test_get_intent_with_No7amItem():
     assert cat_intent_item._label != clean_text
 
 
-def test_get_intent_with_7amItem():
+def test_AgendaUnit_get_intent_With7amItemExample():
     # GIVEN
     # set beliefs as midnight to 8am
     x_agenda = example_agendas_get_agenda_with7amCleanTableReason()
@@ -124,7 +124,7 @@ def test_get_intent_with_7amItem():
     assert clean_item._label == clean_text
 
 
-def test_get_intent_does_not_return_pledge_items_outside_range():
+def test_AgendaUnit_get_intent_DoesNotReturnPledgeItemsOutsideRange():
     zia_text = "Zia"
     zia_agenda = agendaunit_shop(zia_text)
     zia_agenda.set_time_hreg_ideas(c400_count=7)
@@ -159,6 +159,40 @@ def test_get_intent_does_not_return_pledge_items_outside_range():
     assert len(intent_dict) == 0
 
 
+def test_AgendaUnit_get_all_pledges_ReturnsCorrectObj():
+    # GIVEN
+    zia_text = "Zia"
+    zia_agenda = agendaunit_shop(zia_text)
+    casa_text = "casa"
+    casa_road = zia_agenda.make_l1_road(casa_text)
+    clean_text = "clean"
+    clean_road = zia_agenda.make_road(casa_road, clean_text)
+    sweep_text = "sweep"
+    sweep_road = zia_agenda.make_road(clean_road, sweep_text)
+    couch_text = "couch"
+    couch_road = zia_agenda.make_road(casa_road, couch_text)
+    zia_agenda.add_idea(ideaunit_shop(couch_text), casa_road)
+    zia_agenda.add_idea(ideaunit_shop(clean_text, pledge=True), casa_road)
+    zia_agenda.add_idea(ideaunit_shop(sweep_text, pledge=True), clean_road)
+    sweep_idea = zia_agenda.get_idea_obj(sweep_road)
+    bob_text = "Bob"
+    zia_agenda.add_partyunit(bob_text)
+    sweep_idea._assignedunit.set_suffgroup(bob_text)
+    print(f"{sweep_idea}")
+    intent_dict = zia_agenda.get_intent_dict()
+    assert intent_dict.get(clean_road) != None
+    assert intent_dict.get(sweep_road) is None
+    assert intent_dict.get(couch_road) is None
+
+    # WHEN
+    all_pledges_dict = zia_agenda.get_all_pledges()
+
+    # THEN
+    assert all_pledges_dict.get(sweep_road) == zia_agenda.get_idea_obj(sweep_road)
+    assert all_pledges_dict.get(clean_road) == zia_agenda.get_idea_obj(clean_road)
+    assert all_pledges_dict.get(couch_road) is None
+
+
 def test_example_agendas_agenda_v001_IntentExists():
     # GIVEN
     x_agenda = example_agendas_agenda_v001()
@@ -183,7 +217,7 @@ def test_example_agendas_agenda_v001_IntentExists():
     # assert str(type(intent_dict[12])) != "<class 'str'>"
 
 
-def test_exammple_AgendaHasCorrectAttributes():
+def test_example_agendas_agenda_v001_AgendaHasCorrectAttributes():
     # GIVEN
     x_agenda = example_agendas_agenda_v001()
 
@@ -262,7 +296,7 @@ def test_exammple_AgendaHasCorrectAttributes():
     print(len(idea_action_list))
 
 
-def test_exammple_AgendaCanFiltersOnBase():
+def test_example_agendas_agenda_v001_with_large_intent_AgendaCanFiltersOnBase():
     # GIVEN
     x_agenda = example_agendas_agenda_v001_with_large_intent()
     week_text = "weekdays"
@@ -291,7 +325,7 @@ def test_exammple_AgendaCanFiltersOnBase():
     assert len(action_list) == 29
 
 
-def test_set_intent_task_as_complete_SetsAttrCorrectly_Range():
+def test_AgendaUnit_set_intent_task_as_complete_SetsAttrCorrectly_Range():
     # GIVEN
     zia_agenda = agendaunit_shop("Zia")
 
@@ -331,7 +365,7 @@ def test_set_intent_task_as_complete_SetsAttrCorrectly_Range():
     assert intent_dict == {}
 
 
-def test_set_intent_task_as_complete_SetsAttrCorrectly_Division():
+def test_AgendaUnit_set_intent_task_as_complete_SetsAttrCorrectly_Division():
     # GIVEN
     zia_agenda = agendaunit_shop("Zia")
 
@@ -378,7 +412,7 @@ def test_agendaunit_get_from_json_CorrectlyLoadsActionFromJSON():
     x_agenda_json = example_agendas_agenda_v001().get_json()
 
     # WHEN
-    x_agenda = get_from_json(x_agenda_json=x_agenda_json)
+    x_agenda = agendaunit_get_from_json(x_agenda_json=x_agenda_json)
 
     # THEN
     assert len(x_agenda.get_idea_dict()) == 253
@@ -418,7 +452,7 @@ def test_agendaunit_get_from_json_CorrectlyLoadsActionFromJSON():
     assert len(x_agenda.get_intent_dict()) > 0
 
 
-def test_weekdayAgendaItemsCorrectlyReturned():
+def test_set_belief_WeekdayAgendaItemsCorrectlyReturned():
     # GIVEN
     zia_agenda = agendaunit_shop("Zia")
     zia_agenda.set_time_hreg_ideas(c400_count=7)
@@ -547,7 +581,7 @@ def test_weekdayAgendaItemsCorrectlyReturned():
     #     print(f"{belief.base=} (H: {belief.belief}) {belief.=} {belief.open=} {belief.nigh=}")
 
 
-def test_agenda_create_intent_item_CorrectlyCreatesAllAgendaAttributes():
+def test_AgendaUnit_create_intent_item_CorrectlyCreatesAllAgendaAttributes():
     # WHEN "I am cleaning the cookery since I'm in the apartment and it's 8am and it's dirty and I'm doing this for my family"
 
     # GIVEN

--- a/src/agenda/test_agenda/test_agenda_idea_crud.py
+++ b/src/agenda/test_agenda/test_agenda_idea_crud.py
@@ -45,6 +45,23 @@ def test_AgendaUnit_add_idea_RaisesErrorWhen_parent_road_IdeaDoesNotExist():
     )
 
 
+def test_AgendaUnit_add_idea_RaisesErrorWhen_label_IsNotNode():
+    # GIVEN
+    zia_agenda = agendaunit_shop("Zia")
+    swim_road = zia_agenda.make_l1_road("swimming")
+    casa_text = "casa"
+    casa_road = zia_agenda.make_l1_road(casa_text)
+    run_text = "run"
+    run_road = zia_agenda.make_road(casa_road, run_text)
+
+    # WHEN/THEN
+    with pytest_raises(Exception) as excinfo:
+        zia_agenda.add_idea(ideaunit_shop(run_road), parent_road=swim_road)
+    assert (
+        str(excinfo.value) == f"add_idea failed because '{run_road}' is not a RoadNode."
+    )
+
+
 def test_AgendaUnit_add_l1_idea_CorrectlySetsAttr():
     # GIVEN
     zia_agenda = agendaunit_shop("Zia")

--- a/src/listen/listen.py
+++ b/src/listen/listen.py
@@ -190,7 +190,10 @@ def listen_to_speaker_intent(listener: AgendaUnit, speaker: AgendaUnit) -> Agend
 
     if listener._party_debtor_pool is None:
         return _allocate_missing_debtor_weight(listener, speaker._owner_id)
-    intent = generate_perspective_intent(perspective_agenda)
+    if listener._owner_id != speaker._owner_id:
+        intent = generate_perspective_intent(perspective_agenda)
+    else:
+        intent = list(perspective_agenda.get_all_pledges().values())
     if len(intent) == 0:
         return _allocate_missing_debtor_weight(listener, speaker._owner_id)
     return _ingest_perspective_intent(listener, intent)

--- a/src/listen/test__userhub/test_userhub_loop.py
+++ b/src/listen/test__userhub/test_userhub_loop.py
@@ -21,14 +21,14 @@ def test_UserHub_PipelineMethodsReturnCorrectObjs_role_job():
 
     # THEN
     bob_text = "Bob"
-    assert sue_userhub.rj_speaker_file_name(bob_text) == f"{bob_text}.json"
-    assert sue_userhub.rj_speaker_file_name(sue_text) == f"{sue_text}.json"
+    assert sue_userhub.rolejob_role_file_name(bob_text) == f"{bob_text}.json"
+    assert sue_userhub.rolejob_role_file_name(sue_text) == f"{sue_text}.json"
     sue_jobs_dir = sue_userhub.jobs_dir()
-    assert sue_userhub.rj_speaker_dir(healer_id=sue_text) == sue_jobs_dir
+    assert sue_userhub.rolejob_role_dir(healer_id=sue_text) == sue_jobs_dir
     yao_text = "Yao"
     yao_userhub = userhub_shop(temp_env_dir, None, yao_text, nation_road)
     yao_jobs_dir = yao_userhub.jobs_dir()
-    assert sue_userhub.rj_speaker_dir(healer_id=yao_text) == yao_jobs_dir
+    assert sue_userhub.rolejob_role_dir(healer_id=yao_text) == yao_jobs_dir
     yao_bob_job_path = yao_userhub.job_path(bob_text)
     assert yao_bob_job_path == sue_userhub.rj_speaker_file_path(
         healer_id=yao_text, speaker_id=bob_text

--- a/src/listen/userhub.py
+++ b/src/listen/userhub.py
@@ -478,10 +478,10 @@ class UserHub:
     def delete_treasury_db_file(self):
         delete_dir(self.treasury_db_path())
 
-    def rj_speaker_file_name(self, speaker_id: PersonID) -> str:
+    def rolejob_role_file_name(self, speaker_id: PersonID) -> str:
         return get_json_filename(speaker_id)
 
-    def rj_speaker_dir(self, healer_id: PersonID) -> str:
+    def rolejob_role_dir(self, healer_id: PersonID) -> str:
         healer_userhub = userhub_shop(
             self.reals_dir, self.real_id, healer_id, self.econ_road
         )

--- a/src/money/cash.py
+++ b/src/money/cash.py
@@ -1,7 +1,7 @@
 from src.agenda.party import PartyUnit
 
 
-def allot_scale(partys: PartyUnit, scale_number: float, grain_unit):
+def allot_scale(partys: PartyUnit, scale_number: float, grain_unit: float):
     """
     allots the scale_number across partys with creditor_weighted attributes with a resolution of the grain unit.
 

--- a/src/money/test_cash/test_scale_distribution.py
+++ b/src/money/test_cash/test_scale_distribution.py
@@ -42,7 +42,7 @@ def test_allot_scale_v02():
     )
 
 
-def test_allot_scale_v03():
+def test_allot_scale_v03_0():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},
@@ -61,7 +61,7 @@ def test_allot_scale_v03():
     assert sum(obj["alloted_value"] for obj in partys.values()) == scale_number
 
 
-def test_allot_scale_v03():
+def test_allot_scale_v03_1():
     # Example usage:
     partys = {
         "obj1": {"creditor_weight": 1.0},


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new method to retrieve all pledge items in `AgendaUnit`, fixes a loop condition bug, enhances method validations, and renames test functions for consistency. Additionally, new tests are added to verify the new functionalities and validations.

* **New Features**:
    - Introduced a new method `get_all_pledges` in the `AgendaUnit` class to retrieve all pledge items.
* **Bug Fixes**:
    - Fixed an infinite loop condition in `_get_lemma_beliefunits` by correcting the loop condition.
* **Enhancements**:
    - Renamed several test functions in `test_agenda_calc_metrics.py` to follow a consistent naming convention.
    - Added validation in `add_idea` method to ensure the label is a `RoadNode` before proceeding.
    - Updated `listen_to_speaker_intent` to handle intents differently based on the owner ID comparison.
* **Tests**:
    - Added a new test `test_AgendaUnit_get_all_pledges_ReturnsCorrectObj` to verify the functionality of the `get_all_pledges` method.
    - Added a new test `test_AgendaUnit_add_idea_RaisesErrorWhen_label_IsNotNode` to check the new validation in `add_idea` method.

<!-- Generated by sourcery-ai[bot]: end summary -->