### PR TITLE
699 create tool for validating sound excel files data types given idea schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,36 @@ JAAR Version 0.0.0
 So how do I listen? jaar has an engine for converting the declarations (as data) into task lists. How to input the data? The most excessable method is using excel sheets. 
 
 # 0.0.1 "Vows" The foundation of jaar
-For Levinas all of reality is born from the face to face encounter. The same (me) welcomes the other person through the Face. The Face of the other tells me it's suffering and it's suffering becomes my suffering. I then VOW to change who I am to ease that suffering. The suffering is infinitly deep and beyond my complete understanding so when I vow to respond to that suffering I am acting with confidence that I understand what the suffering is and that I know how to respond. That confidence stops the listening process, the Vow cuts the infinite into the finite and is the foundation for a world. When that Vow is created it can create a world. Worlds can hold a infinite amount of human experience. A small subset of that is logical systems. Jaar is uses computers to build logic.
+For Levinas all of reality is born from the face to face encounter. The same (me) welcomes the other person through the Face. The Face of the other tells me it's suffering and it's suffering becomes my suffering. I then VOW to change who I am to ease that suffering. The suffering is infinitly deep and beyond my complete understanding so when I vow to respond to that suffering I am acting with confidence that I understand what the suffering is and that I know how to respond. That confidence stops the listening process, the Vow cuts the infinite into the finite and is the foundation for a world. When that Vow is created it can create a world. Worlds can hold a infinite amount of human experience. A small subset of that is logical systems. jaar is uses computers to build logic.
 
 A Vow can create a world or change a current world. Each person can only make one vow at a time so a world that has been built by multiple vows implies each vow is from a different time. jaar describes the passage of time by *event_ints*. *event_int* is always an integer. 
 
-For jaar all data must have *event_int*, *face_name*, *vow_label*
+For jaar all data must have *event_int*, *face_name*, *vow_label*. These are the required keys.
 
   
 ## 0.1 Short introduction to jaar excel sheets
 
-`jaar` is a python library for generating a calendar agenda based on the needs of my neighbors and in turn letting them know what I need. Needs can be expressed in Excel sheets that range in complexity from a simple five column single row (example below) to 10+ columns that include configuration options that are usually set to defaults.
+`jaar` is a python library for listening to the needs of my neighbors and in turn letting them know what I need. Needs can be expressed in Excel sheets that range in complexity from a simple five column single row (example below) to 10+ columns that include configuration options that are usually set to defaults. Each row is interpreted and used to build the "clarity" data set. Even sheet with a single row like the example 0.1.0 below can be processed by jaar. 
 
-# Example 0.1.0
+# Input Example Excel file 0.1.0: fizz0.xlsx with sheet "br00000_buzz" 
 | event_int | face_name | vow_label | owner_name | acct_name | tran_time | amount |
 |-----------|-----------|-----------|------------|-----------|-----------|--------|
 |    77     | Emmanuel  | OxboxDean |  Emmanuel  |    Dean   |    891    |  7000  |
 
-A sheet with a single row like the example above can be processed by jaar. Jaar takes the sheet, creates a fiscal environemnt named "OxbowDean" and within that fiscal environment creates an owner named "Emmanuel" who has a plan.
-
-Outputs (simplied):
-emmanuel_stance.xlsx: sheet "br00000"
-| event_int | face_name |  vow_label | ...
-|    78     | Emmanuel  |  OxboxDean |  Emmanuel  |    Dean   |      100      |      15       |
-
+When jaar processes example 0.1.0 it creates a Vow labeled "OxboxDean" that contains owners Emmanuel and Dean and a single transaction of 7000 OxboxDean coins from Emmanuel to Dean. Here's the status metrics:
+| vow_label | owner_name | vow_fund_amount | vow_fund_rank | vow_tasks |
+|-----------|------------|-----------------|---------------|-----------|
+| OxboxDean |  Emmanuel  |     -7000       |       2       |     0     |
+| OxboxDean |    Dean    |      7000       |       1       |     0     |
 
 
+Output stance: emmanuel_stance.xlsx, sheet "br00000"
+| event_int | face_name | vow_label | owner_name | acct_name | tran_time | amount |
+|-----------|-----------|-----------|------------|-----------|-----------|--------|
+|    77     | Emmanuel  | OxboxDean |  Emmanuel  |    Dean   |    891    |  7000  |
 
-That plan involves listening to Dean. Consider this slightly more complex start:
 
-
+<!-- # Input Example Excel file 0.1.2: fizz2.xlsx with sheet "br00000_buzz2" 
 | event_int | face_name | vow_label | owner_name | acct_name | credit_score | debtit_score |
 |-----------|-----------|-----------|------------|-----------|---------------|---------------|
 |    77     | Emmanuel  | OxboxDean |  Emmanuel  |    Dean   |      100      |      15       |
@@ -54,7 +55,7 @@ That plan involves listening to Dean. Consider this slightly more complex start:
 |    78     |    Sue    | OxboxDean |     Sue    |     Sue   |       2       |       7       |
 |    78     |    Sue    | OxboxDean |     Sue    |     Sue   |       50      |      75       |
 
-
+ -->
 
 `jaar` is a python library for listening to the climate of a community. Individual 
 positions are aggregated by a listener into a coherant agenda that can include tasks 
@@ -130,7 +131,7 @@ PlanUnit ConceptUnit FactHeir objects1
 
 ## 1.3 Test-Driven-Development
 
-Jaar was developed using Test-Driven-Development so every feature should have a test. 
+jaar was developed using Test-Driven-Development so every feature should have a test. 
 Tests can be hard to comprehend. Some tests have many variables and can be hard to follow.
 
 <!-- TODO: Add examples 

--- a/src/a02_finance_logic/deal_db.py
+++ b/src/a02_finance_logic/deal_db.py
@@ -1,0 +1,24 @@
+from sqlite3 import Cursor
+from src.a02_finance_logic.deal import TranBook
+
+
+def insert_tranunit_accts_net(cursor: Cursor, tranbook: TranBook, dst_tablename: str):
+    """
+    Insert the net amounts for each account in the tranbook into the specified table.
+
+    :param cursor: SQLite cursor object
+    :param tranbook: TranBook object containing transaction units
+    :param dst_tablename: Name of the destination table
+    """
+    create_table_sql = f"""
+    CREATE TABLE IF NOT EXISTS {dst_tablename} (
+        owner_name TEXT NOT NULL,
+        net_amount REAL NOT NULL
+    );
+    """
+    cursor.execute(create_table_sql)
+    accts_net_array = tranbook._get_accts_net_array()
+    cursor.executemany(
+        f"INSERT INTO {dst_tablename} (owner_name, net_amount) VALUES (?, ?)",
+        accts_net_array,
+    )

--- a/src/a02_finance_logic/test_deal/test_tran_db.py
+++ b/src/a02_finance_logic/test_deal/test_tran_db.py
@@ -1,0 +1,55 @@
+from sqlite3 import connect as sqlite3_connect
+from src.a00_data_toolbox.db_toolbox import db_table_exists, get_row_count
+from src.a02_finance_logic._test_util.a02_str import acct_name_str, vow_label_str
+from src.a02_finance_logic.deal import (
+    TranBook,
+    TranUnit,
+    get_tranbook_from_dict,
+    tranbook_shop,
+    tranunit_shop,
+)
+from src.a02_finance_logic.deal_db import insert_tranunit_accts_net
+
+
+def test_insert_tranunit_accts_net_PopulatesDatabase():
+    # ESTABLISH
+    a23_str = "accord23"
+    a23_tranbook = tranbook_shop(a23_str)
+    sue_str = "Sue"
+    yao_str = "Yao"
+    bob_str = "Bob"
+    t55_tran_time = 5505
+    t55_yao_amount = -55
+    t55_bob_amount = 600
+    t66_tran_time = 6606
+    t66_yao_amount = -66
+    t77_tran_time = 7707
+    t77_yao_amount = -77
+    a23_tranbook.add_tranunit(sue_str, yao_str, t55_tran_time, t55_yao_amount)
+    a23_tranbook.add_tranunit(sue_str, yao_str, t66_tran_time, t66_yao_amount)
+    a23_tranbook.add_tranunit(sue_str, bob_str, t55_tran_time, t55_bob_amount)
+    a23_tranbook.add_tranunit(yao_str, yao_str, t77_tran_time, t77_yao_amount)
+    accord23_accts_net_array = a23_tranbook._get_accts_net_array()
+    assert accord23_accts_net_array == [
+        [bob_str, t55_bob_amount],
+        [yao_str, t55_yao_amount + t66_yao_amount + t77_yao_amount],
+    ]
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        dst_tablename = "tranbook_accts_net"
+        assert not db_table_exists(cursor, dst_tablename)
+
+        # WHEN
+        insert_tranunit_accts_net(cursor, a23_tranbook, dst_tablename)
+
+        # THEN
+        assert db_table_exists(cursor, dst_tablename)
+        assert get_row_count(cursor, dst_tablename) == 2
+        cursor.execute(f"SELECT owner_name, net_amount FROM {dst_tablename}")
+        rows = cursor.fetchall()
+        assert rows == [
+            (bob_str, t55_bob_amount),
+            (yao_str, t55_yao_amount + t66_yao_amount + t77_yao_amount),
+        ]
+
+    assert 1 == 2

--- a/src/a02_finance_logic/test_deal/test_tran_db.py
+++ b/src/a02_finance_logic/test_deal/test_tran_db.py
@@ -51,5 +51,3 @@ def test_insert_tranunit_accts_net_PopulatesDatabase():
             (bob_str, t55_bob_amount),
             (yao_str, t55_yao_amount + t66_yao_amount + t77_yao_amount),
         ]
-
-    assert 1 == 2

--- a/src/a08_plan_atom_logic/atom.py
+++ b/src/a08_plan_atom_logic/atom.py
@@ -688,7 +688,6 @@ def sift_planatom(x_plan: PlanUnit, x_atom: PlanAtom) -> PlanAtom:
     x_atom_reqs = {x_key: x_atom.get_value(x_key) for x_key in config_keys}
 
     x_exists = plan_attr_exists(x_atom.dimen, x_plan, x_atom_reqs)
-    print(f"{x_exists=}")
 
     if x_atom.crud_str == "DELETE" and x_exists:
         return x_atom

--- a/src/a19_world_logic/test/test_world_.py
+++ b/src/a19_world_logic/test/test_world_.py
@@ -253,3 +253,13 @@ def test_WorldUnit_get_event_ReturnsObj(env_dir_setup_cleanup):
 
     # THEN
     assert x_world.get_event(e5_event_int) == e5_face_name
+
+
+def test_WorldUnit_get_db_path_ReturnsObj(env_dir_setup_cleanup):
+    # ESTABLISH
+    a23_world = worldunit_shop("accord23", worlds_dir())
+
+    # WHEN
+    a23_db_path = a23_world.get_db_path()
+
+    assert a23_db_path == create_path(a23_world._world_dir, "world.db")

--- a/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
@@ -491,3 +491,109 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario3_CreatesFiles(
         assert os_path_exists(a23_sue_job_path)
         assert os_path_exists(sue37_mandate_path)
         assert count_dirs_files(fizz_world.worlds_dir) == 43
+
+
+def test_WorldUnit_mud_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH:
+    fizz_str = "fizz"
+    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    # delete_dir(fizz_world.worlds_dir)
+    sue_str = "Sue"
+    sue_inx = "Suzy"
+    e3 = 3
+    ex_filename = "fizzbuzz.xlsx"
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+    br00113_columns = [
+        face_name_str(),
+        event_int_str(),
+        vow_label_str(),
+        owner_name_str(),
+        acct_name_str(),
+        otx_name_str(),
+        inx_name_str(),
+    ]
+    a23_str = "accord23"
+    tp37 = 37
+    br00113_str = "br00113"
+    br00113row0 = [sue_str, e3, a23_str, sue_str, sue_str, sue_str, sue_inx]
+    br00113_df = DataFrame([br00113row0], columns=br00113_columns)
+    br00113_ex0_str = f"example0_{br00113_str}"
+    upsert_sheet(mud_file_path, br00113_ex0_str, br00113_df)
+
+    br00001_columns = [
+        event_int_str(),
+        face_name_str(),
+        vow_label_str(),
+        owner_name_str(),
+        deal_time_str(),
+        quota_str(),
+        celldepth_str(),
+    ]
+    tp37 = 37
+    sue_quota = 235
+    sue_celldepth = 3
+    br1row0 = [e3, sue_str, a23_str, sue_str, tp37, sue_quota, sue_celldepth]
+    br00001_1df = DataFrame([br1row0], columns=br00001_columns)
+    br00001_ex0_str = "example0_br00001"
+    upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
+    fizz_db_path = fizz_world.get_db_path()
+    assert not os_path_exists(fizz_db_path)
+
+    # WHEN
+    fizz_world.mud_to_clarity_mstr()
+
+    # THEN
+    assert os_path_exists(fizz_db_path)
+    with sqlite3_connect(fizz_db_path) as db_conn:
+        br00113_raw = f"{br00113_str}_brick_raw"
+        br00113_agg = f"{br00113_str}_brick_agg"
+        br00113_valid = f"{br00113_str}_brick_valid"
+        events_brick_agg_tablename = "events_brick_agg"
+        events_brick_valid_tablename = "events_brick_valid"
+        vow_ote1_agg_tablename = "vow_ote1_agg"
+        pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
+        pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
+        pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
+        pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
+        pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
+        pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
+        fisunit_sound_raw = create_prime_tablename("fisunit", "s", "raw")
+        fisunit_sound_agg = create_prime_tablename("fisunit", "s", "agg")
+        planunit_sound_put_raw = create_prime_tablename("planunit", "s", "raw", "put")
+        planunit_sound_put_agg = create_prime_tablename("planunit", "s", "agg", "put")
+        planacct_sound_put_raw = create_prime_tablename("planacct", "s", "raw", "put")
+        planacct_sound_put_agg = create_prime_tablename("planacct", "s", "agg", "put")
+        fisunit_voice_raw = create_prime_tablename("fisunit", "v", "raw")
+        fisunit_voice_agg = create_prime_tablename("fisunit", "v", "agg")
+        planunit_voice_put_raw = create_prime_tablename("planunit", "v", "raw", "put")
+        planunit_voice_put_agg = create_prime_tablename("planunit", "v", "agg", "put")
+        planacct_voice_put_raw = create_prime_tablename("planacct", "v", "raw", "put")
+        planacct_voice_put_agg = create_prime_tablename("planacct", "v", "agg", "put")
+
+        cursor = db_conn.cursor()
+        assert get_row_count(cursor, br00113_raw) == 1
+        assert get_row_count(cursor, br00113_agg) == 1
+        assert get_row_count(cursor, events_brick_agg_tablename) == 2
+        assert get_row_count(cursor, events_brick_valid_tablename) == 2
+        assert get_row_count(cursor, br00113_valid) == 2
+        assert get_row_count(cursor, pidname_sound_raw) == 2
+        assert get_row_count(cursor, fisunit_sound_raw) == 4
+        assert get_row_count(cursor, planunit_sound_put_raw) == 4
+        assert get_row_count(cursor, planacct_sound_put_raw) == 2
+        assert get_row_count(cursor, pidname_sound_agg) == 1
+        assert get_row_count(cursor, fisunit_sound_agg) == 1
+        assert get_row_count(cursor, planunit_sound_put_agg) == 1
+        assert get_row_count(cursor, planacct_sound_put_agg) == 1
+        assert get_row_count(cursor, pidcore_sound_raw) == 1
+        assert get_row_count(cursor, pidcore_sound_agg) == 1
+        assert get_row_count(cursor, pidcore_sound_vld) == 1
+        assert get_row_count(cursor, pidname_sound_vld) == 1
+        assert get_row_count(cursor, fisunit_voice_raw) == 1
+        assert get_row_count(cursor, planunit_voice_put_raw) == 1
+        assert get_row_count(cursor, planacct_voice_put_raw) == 1
+        assert get_row_count(cursor, fisunit_voice_agg) == 1
+        assert get_row_count(cursor, planunit_voice_put_agg) == 1
+        assert get_row_count(cursor, planacct_voice_put_agg) == 1
+        assert get_row_count(cursor, vow_ote1_agg_tablename) == 1

--- a/src/a19_world_logic/test_etl_pipeline/test_stance_export.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_stance_export.py
@@ -24,7 +24,7 @@ def test_WorldUnit_create_stances_Senario0_EmptyWorld_CreatesFile(
     # ESTABLISH
     fizz_str = "fizz"
     fizz_world = worldunit_shop(fizz_str, worlds_dir())
-    fizz_world.mud_to_clarity()
+    fizz_world.mud_to_clarity_mstr()
     fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -54,7 +54,7 @@ def test_WorldUnit_create_stances_Senario1_Add_CreatesFile(env_dir_setup_cleanup
     br00011_rows = [[event2, sue_str, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-    fizz_world.mud_to_clarity()
+    fizz_world.mud_to_clarity_mstr()
     fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
     assert os_path_exists(fizz_stance0001_path) is False
 
@@ -86,7 +86,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     br00011_rows = [[event2, sue_str, accord23_str, sue_str, sue_str]]
     br00011_df = DataFrame(br00011_rows, columns=br00011_columns)
     upsert_sheet(mud_file_path, "br00011_ex3", br00011_df)
-    fizz_world.mud_to_clarity()
+    fizz_world.mud_to_clarity_mstr()
     fizz_stance0001_path = create_stance0001_path(fizz_world._vow_mstr_dir)
     fizz_world.create_stances()
     buzz_world = worldunit_shop("buzz", worlds_dir())
@@ -97,7 +97,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
     # print(f"{pandas_read_excel(buzz_mud_st0001_path)=}")
     print(f"{buzz_mud_st0001_path=}")
     print(f"{get_sheet_names(buzz_mud_st0001_path)=}")
-    buzz_world.mud_to_clarity()
+    buzz_world.mud_to_clarity_mstr()
     buzz_stance0001_path = create_stance0001_path(buzz_world._vow_mstr_dir)
     assert os_path_exists(buzz_stance0001_path) is False
 
@@ -190,7 +190,7 @@ def test_WorldUnit_create_stances_Senario2_CreatedStanceCanBeIdeasForOtherWorldU
 #     assert count_dirs_files(fizz_world.worlds_dir) == 7
 
 #     # WHEN
-#     fizz_world.mud_to_clarity()
+#     fizz_world.mud_to_clarity_mstr()
 
 #     # THEN
 #     assert os_path_exists(wrong_a23_vow_dir) is False

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -65,6 +65,9 @@ class WorldUnit:
     _events: dict[EventInt, FaceName] = None
     _pidgin_events: dict[FaceName, set[EventInt]] = None
 
+    def get_db_path(self) -> str:
+        return create_path(self._world_dir, "world.db")
+
     def set_event(self, event_int: EventInt, face_name: FaceName):
         self._events[event_int] = face_name
 
@@ -110,10 +113,11 @@ class WorldUnit:
         etl_set_cell_tree_cell_mandates(mstr_dir)
         etl_create_deal_mandate_ledgers(mstr_dir)
 
-    def mud_to_clarity(self, store_tracing_files: bool = False):
-        with sqlite3_connect(":memory:") as db_conn:
+    def mud_to_clarity_mstr(self, store_tracing_files: bool = False):
+        with sqlite3_connect(self.get_db_path()) as db_conn:
             cursor = db_conn.cursor()
             self.mud_to_clarity_with_cursor(db_conn, cursor, store_tracing_files)
+            db_conn.commit()
 
     def mud_to_clarity_with_cursor(
         self,


### PR DESCRIPTION
## Summary by Sourcery

Persist ETL output to a SQLite file by renaming and enhancing the mud_to_clarity pipeline, add a method to locate the DB, and introduce a finance helper for inserting net account balances, accompanied by corresponding tests and README updates

New Features:
- Introduce persistent SQLite pipeline method mud_to_clarity_mstr with world.db storage
- Add get_db_path helper for WorldUnit to locate the database file
- Provide insert_tranunit_accts_net utility to populate account net amounts in finance DB

Enhancements:
- Rename mud_to_clarity to mud_to_clarity_mstr and commit database transactions
- Remove extraneous debug print from atom.sift_planatom

Documentation:
- Revise README to detail Excel input/output examples and clarify required data keys

Tests:
- Add tests for get_db_path, mud_to_clarity_mstr workflow, and insert_tranunit_accts_net functionality
- Update existing stance export tests to invoke mud_to_clarity_mstr