### PR TITLE
699 create tool for validating sound excel files data types given idea schema

### DIFF
--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -16,7 +16,7 @@
 - a12_hub_tools: gut, job
 - a13_plan_listen_logic: 
 - a14_keep_logic: 
-- a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
+- a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_bridge, inx_label, inx_name, inx_title, inx_way, map_otx2inx, otx2inx, otx_bridge, otx_key, otx_label, otx_name, otx_title, otx_way, pidgin_core, pidgin_label, pidgin_name, pidgin_title, pidgin_way, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_agg, brick_raw, brick_valid, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, sound_agg, sound_raw, voice_agg, voice_raw, world_id
 - a18_etl_toolbox: 

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -19,6 +19,6 @@
 - a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_bridge, inx_label, inx_name, inx_title, inx_way, map_otx2inx, otx2inx, otx_bridge, otx_key, otx_label, otx_name, otx_title, otx_way, pidgin_core, pidgin_label, pidgin_name, pidgin_title, pidgin_way, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_agg, brick_raw, brick_valid, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, sound_agg, sound_raw, voice_agg, voice_raw, world_id
-- a18_etl_toolbox: events_brick_agg, events_brick_valid, vow_acct_nets, vow_event_time_agg, vow_kpi001_acct_nets
+- a18_etl_toolbox: events_brick_agg, events_brick_valid, vow_event_time_agg
 - a19_world_logic: 
 - a20_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -19,6 +19,6 @@
 - a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_bridge, inx_label, inx_name, inx_title, inx_way, map_otx2inx, otx2inx, otx_bridge, otx_key, otx_label, otx_name, otx_title, otx_way, pidgin_core, pidgin_label, pidgin_name, pidgin_title, pidgin_way, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_agg, brick_raw, brick_valid, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, sound_agg, sound_raw, voice_agg, voice_raw, world_id
-- a18_etl_toolbox: events_brick_agg, events_brick_valid
+- a18_etl_toolbox: events_brick_agg, events_brick_valid, vow_event_time_agg
 - a19_world_logic: 
 - a20_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -19,6 +19,6 @@
 - a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_bridge, inx_label, inx_name, inx_title, inx_way, map_otx2inx, otx2inx, otx_bridge, otx_key, otx_label, otx_name, otx_title, otx_way, pidgin_core, pidgin_label, pidgin_name, pidgin_title, pidgin_way, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_agg, brick_raw, brick_valid, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, sound_agg, sound_raw, voice_agg, voice_raw, world_id
-- a18_etl_toolbox: events_brick_agg, events_brick_valid, vow_event_time_agg
+- a18_etl_toolbox: events_brick_agg, events_brick_valid, vow_acct_nets, vow_event_time_agg, vow_kpi001_acct_nets
 - a19_world_logic: 
 - a20_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -13,12 +13,12 @@
 - a09_pack_logic: event_int, face_name
 - a10_plan_calc: jmetrics, plan_groupunit
 - a11_deal_cell_logic: boss_facts, deal_owner_name, found_facts, planadjust, planevent_facts
-- a12_hub_tools: gut, job
+- a12_hub_tools: gut, job, vow_ote1_agg
 - a13_plan_listen_logic: 
 - a14_keep_logic: 
 - a15_vow_logic: brokerunits, cumlative_day, cumlative_minute, hour_label, job_listen_rotations, month_label, paybook, vow_dealunit, vow_paybook, vow_timeline_hour, vow_timeline_month, vow_timeline_weekday, vow_timeoffi, vowunit, weekday_label, weekday_order
 - a16_pidgin_logic: inx_bridge, inx_label, inx_name, inx_title, inx_way, map_otx2inx, otx2inx, otx_bridge, otx_key, otx_label, otx_name, otx_title, otx_way, pidgin_core, pidgin_label, pidgin_name, pidgin_title, pidgin_way, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, brick_agg, brick_raw, brick_valid, build_order, delete_insert, delete_insert_update, delete_update, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, sound_agg, sound_raw, voice_agg, voice_raw, world_id
-- a18_etl_toolbox: 
+- a18_etl_toolbox: events_brick_agg, events_brick_valid
 - a19_world_logic: 
 - a20_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/src/a03_group_logic/acct.py
+++ b/src/a03_group_logic/acct.py
@@ -192,8 +192,8 @@ class AcctUnit(AcctCore):
             for x_membership in self._memberships.values()
         }
         allot_dict = allot_scale(ledger_dict, self._credor_pool, self.respect_bit)
-        for x_group_title, group_credor_pool in allot_dict.items():
-            self.get_membership(x_group_title)._credor_pool = group_credor_pool
+        for x_group_title, alloted_pool in allot_dict.items():
+            self.get_membership(x_group_title)._credor_pool = alloted_pool
 
     def set_debtor_pool(self, debtor_pool: RespectNum):
         self._debtor_pool = debtor_pool
@@ -202,8 +202,8 @@ class AcctUnit(AcctCore):
             for x_membership in self._memberships.values()
         }
         allot_dict = allot_scale(ledger_dict, self._debtor_pool, self.respect_bit)
-        for x_group_title, group_debtor_pool in allot_dict.items():
-            self.get_membership(x_group_title)._debtor_pool = group_debtor_pool
+        for x_group_title, alloted_pool in allot_dict.items():
+            self.get_membership(x_group_title)._debtor_pool = alloted_pool
 
     def get_memberships_dict(self) -> dict:
         return {

--- a/src/a12_hub_tools/_test_util/a12_str.py
+++ b/src/a12_hub_tools/_test_util/a12_str.py
@@ -7,3 +7,7 @@ def gut_str() -> Literal["gut"]:
 
 def job_str() -> Literal["job"]:
     return "job"
+
+
+def vow_ote1_agg_str() -> Literal["vow_ote1_agg"]:
+    return "vow_ote1_agg"

--- a/src/a12_hub_tools/_test_util/test_a12_str.py
+++ b/src/a12_hub_tools/_test_util/test_a12_str.py
@@ -1,7 +1,8 @@
-from src.a12_hub_tools._test_util.a12_str import gut_str, job_str
+from src.a12_hub_tools._test_util.a12_str import gut_str, job_str, vow_ote1_agg_str
 
 
 def test_str_functions_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert gut_str() == "gut"
     assert job_str() == "job"
+    assert vow_ote1_agg_str() == "vow_ote1_agg"

--- a/src/a15_vow_logic/_test_util/a15_str.py
+++ b/src/a15_vow_logic/_test_util/a15_str.py
@@ -1,4 +1,12 @@
-from src.a02_finance_logic._test_util.a02_str import amount_str, offi_time_str
+from src.a01_term_logic._test_util.a01_str import bridge_str
+from src.a02_finance_logic._test_util.a02_str import (
+    amount_str,
+    fund_iota_str,
+    offi_time_str,
+    penny_str,
+    vow_label_str,
+)
+from src.a03_group_logic._test_util.a03_str import respect_bit_str
 from src.a06_plan_logic._test_util.a06_str import timeline_str
 
 

--- a/src/a15_vow_logic/_test_util/a15_str.py
+++ b/src/a15_vow_logic/_test_util/a15_str.py
@@ -18,6 +18,10 @@ def hour_label_str() -> str:
     return "hour_label"
 
 
+def job_listen_rotations_str() -> str:
+    return "job_listen_rotations"
+
+
 def month_label_str() -> str:
     return "month_label"
 

--- a/src/a15_vow_logic/_test_util/test_a15_str.py
+++ b/src/a15_vow_logic/_test_util/test_a15_str.py
@@ -3,6 +3,7 @@ from src.a15_vow_logic._test_util.a15_str import (
     cumlative_day_str,
     cumlative_minute_str,
     hour_label_str,
+    job_listen_rotations_str,
     month_label_str,
     paybook_str,
     vow_dealunit_str,
@@ -33,3 +34,4 @@ def test_str_functions_ReturnsObj():
     assert vow_timeline_month_str() == "vow_timeline_month"
     assert vow_timeline_weekday_str() == "vow_timeline_weekday"
     assert vow_timeoffi_str() == "vow_timeoffi"
+    assert job_listen_rotations_str() == "job_listen_rotations"

--- a/src/a15_vow_logic/test_vow_/test_vow_.py
+++ b/src/a15_vow_logic/test_vow_/test_vow_.py
@@ -25,6 +25,17 @@ from src.a15_vow_logic._test_util.a15_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,
 )
+from src.a15_vow_logic._test_util.a15_str import (
+    bridge_str,
+    brokerunits_str,
+    fund_iota_str,
+    job_listen_rotations_str,
+    paybook_str,
+    penny_str,
+    respect_bit_str,
+    timeline_str,
+    vow_label_str,
+)
 from src.a15_vow_logic.vow import VowUnit, get_default_job_listen_count, vowunit_shop
 
 
@@ -54,6 +65,25 @@ def test_VowUnit_Exists():
     assert not accord_vow._journal_db
     assert not accord_vow._packs_dir
     assert not accord_vow._all_tranbook
+    assert set(accord_vow.__dict__) == {
+        vow_label_str(),
+        timeline_str(),
+        brokerunits_str(),
+        paybook_str(),
+        "offi_times",
+        bridge_str(),
+        fund_iota_str(),
+        respect_bit_str(),
+        penny_str(),
+        job_listen_rotations_str(),
+        "_vow_dir",
+        "vow_mstr_dir",
+        "_all_tranbook",
+        "_journal_db",
+        "_offi_time_max",
+        "_owners_dir",
+        "_packs_dir",
+    }
 
 
 def test_vowunit_shop_ReturnsVowUnit():

--- a/src/a15_vow_logic/test_vow_config/test_vow_config_.py
+++ b/src/a15_vow_logic/test_vow_config/test_vow_config_.py
@@ -110,6 +110,7 @@ def test_get_vow_config_dict_ReturnsObj():
         timeline_label_str(),
         yr1_jan1_offset_str(),
         "job_listen_rotations",
+        # job_listen_rotations_str(),
     }
     print(f"{vowunit_dict.get(jvalues_str()).keys()=}")
     gen_jvalues = set(vowunit_dict.get(jvalues_str()).keys())
@@ -248,6 +249,7 @@ def test_get_vow_args_set_ReturnsObj():
         fund_iota_str(),
         month_label_str(),
         monthday_distortion_str(),
+        # job_listen_rotations_str(),
         "job_listen_rotations",
         penny_str(),
         owner_name_str(),

--- a/src/a17_idea_logic/_test_util/idea_df_examples.py
+++ b/src/a17_idea_logic/_test_util/idea_df_examples.py
@@ -1,4 +1,29 @@
 from pandas import DataFrame
+from src.a02_finance_logic._test_util.a02_str import (
+    acct_name_str,
+    amount_str,
+    bridge_str,
+    celldepth_str,
+    deal_time_str,
+    fund_iota_str,
+    owner_name_str,
+    penny_str,
+    quota_str,
+    tran_time_str,
+    vow_label_str,
+)
+from src.a03_group_logic._test_util.a03_str import respect_bit_str
+from src.a07_calendar_logic._test_util.a07_str import (
+    c400_number_str,
+    monthday_distortion_str,
+    timeline_label_str,
+    yr1_jan1_offset_str,
+)
+from src.a15_vow_logic._test_util.a15_str import (
+    job_listen_rotations_str,
+    weekday_label_str,
+    weekday_order_str,
+)
 
 ACCORD23_STR = "accord23"
 JEFFY45_STR = "jeffy45"
@@ -10,16 +35,16 @@ def get_ex1_br00000_df() -> DataFrame:
     """
     x_df = DataFrame(
         columns=[
-            "c400_number",
-            "vow_label",
-            "fund_iota",
-            "monthday_distortion",
-            "penny",
-            "respect_bit",
-            "bridge",
-            "timeline_label",
-            "yr1_jan1_offset",
-            "job_listen_rotations",
+            c400_number_str(),
+            vow_label_str(),
+            fund_iota_str(),
+            monthday_distortion_str(),
+            penny_str(),
+            respect_bit_str(),
+            bridge_str(),
+            timeline_label_str(),
+            yr1_jan1_offset_str(),
+            job_listen_rotations_str(),
         ]
     )
     x_df.loc[0] = [7, ACCORD23_STR, 1, 1, 1, 1, "/", "creg", 440640, 7]
@@ -31,11 +56,11 @@ def get_ex1_br00001_df() -> DataFrame:
     vow_label,owner_name,quota,deal_time,celldepth"""
     x_df = DataFrame(
         columns=[
-            "vow_label",
-            "owner_name",
-            "quota",
-            "deal_time",
-            "celldepth",
+            vow_label_str(),
+            owner_name_str(),
+            quota_str(),
+            deal_time_str(),
+            celldepth_str(),
         ]
     )
     x_df.loc[0] = [ACCORD23_STR, "Sue", 445, 777, 5]
@@ -105,7 +130,9 @@ def get_ex1_br00004_df() -> DataFrame:
 def get_ex1_br00005_df() -> DataFrame:
     """idea_format_00005_vow_timeline_weekday_v0_0_0
     vow_label,weekday_label,weekday_order"""
-    x_df = DataFrame(columns=["vow_label", "weekday_label", "weekday_order"])
+    x_df = DataFrame(
+        columns=[vow_label_str(), weekday_label_str(), weekday_order_str()]
+    )
     x_df.loc[0] = [ACCORD23_STR, "Wednesday", 0]
     x_df.loc[1] = [ACCORD23_STR, "Thursday", 1]
     x_df.loc[2] = [ACCORD23_STR, "Friday", 2]
@@ -122,16 +149,16 @@ def get_ex2_br00000_df() -> DataFrame:
     """
     x_df = DataFrame(
         columns=[
-            "c400_number",
-            "vow_label",
-            "fund_iota",
-            "monthday_distortion",
-            "penny",
-            "respect_bit",
-            "bridge",
-            "timeline_label",
-            "yr1_jan1_offset",
-            "job_listen_rotations",
+            c400_number_str(),
+            vow_label_str(),
+            fund_iota_str(),
+            monthday_distortion_str(),
+            penny_str(),
+            respect_bit_str(),
+            bridge_str(),
+            timeline_label_str(),
+            yr1_jan1_offset_str(),
+            job_listen_rotations_str(),
         ]
     )
     x_df.loc[0] = [7, ACCORD23_STR, 1, 1, 1, 1, "/", "creg", 440640, 4]
@@ -144,11 +171,11 @@ def get_ex2_br00001_df() -> DataFrame:
     vow_label,owner_name,quota,deal_time"""
     x_df = DataFrame(
         columns=[
-            "vow_label",
-            "owner_name",
-            "quota",
-            "deal_time",
-            "celldepth",
+            vow_label_str(),
+            owner_name_str(),
+            quota_str(),
+            deal_time_str(),
+            celldepth_str(),
         ]
     )
     x_df.loc[0] = [ACCORD23_STR, "Bob", 332, 999, 3]
@@ -163,7 +190,13 @@ def get_ex2_br00002_df() -> DataFrame:
     """idea_format_00002_vow_paybook_v0_0_0
     acct_name,amount,vow_label,owner_name,tran_time"""
     x_df = DataFrame(
-        columns=["acct_name", "amount", "vow_label", "owner_name", "tran_time"]
+        columns=[
+            acct_name_str(),
+            amount_str(),
+            vow_label_str(),
+            owner_name_str(),
+            tran_time_str(),
+        ]
     )
     x_df.loc[0] = ["Zia", 888, ACCORD23_STR, "Bob", 777]
     x_df.loc[1] = ["Zia", 234, ACCORD23_STR, "Sue", 999]

--- a/src/a17_idea_logic/test_idea_/test_idea__config.py
+++ b/src/a17_idea_logic/test_idea_/test_idea__config.py
@@ -90,6 +90,7 @@ from src.a15_vow_logic._test_util.a15_str import (
     cumlative_day_str,
     cumlative_minute_str,
     hour_label_str,
+    job_listen_rotations_str,
     month_label_str,
     offi_time_str,
     vow_dealunit_str,
@@ -360,7 +361,7 @@ def test_get_idea_elements_sort_order_ReturnsObj():
     assert table_sorting_priority[138] == "unknown_str"
     assert table_sorting_priority[139] == "quota"
     assert table_sorting_priority[140] == "celldepth"
-    assert table_sorting_priority[141] == "job_listen_rotations"
+    assert table_sorting_priority[141] == job_listen_rotations_str()
     assert table_sorting_priority[142] == "error_message"
     assert table_sorting_priority[143] == "_owner_name_labor"
     assert table_sorting_priority[144] == "_active"
@@ -910,7 +911,7 @@ def test_get_quick_ideas_column_ref_ReturnsObj():
         bridge_str(),
         timeline_label_str(),
         yr1_jan1_offset_str(),
-        "job_listen_rotations",
+        job_listen_rotations_str(),
     }
 
 

--- a/src/a18_etl_toolbox/_test_util/a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/a18_str.py
@@ -7,3 +7,7 @@ def events_brick_agg_str() -> Literal["events_brick_agg"]:
 
 def events_brick_valid_str() -> Literal["events_brick_valid"]:
     return "events_brick_valid"
+
+
+def vow_event_time_agg_str() -> str:
+    return "vow_event_time_agg"

--- a/src/a18_etl_toolbox/_test_util/a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/a18_str.py
@@ -1,0 +1,9 @@
+from typing import Literal
+
+
+def events_brick_agg_str() -> Literal["events_brick_agg"]:
+    return "events_brick_agg"
+
+
+def events_brick_valid_str() -> Literal["events_brick_valid"]:
+    return "events_brick_valid"

--- a/src/a18_etl_toolbox/_test_util/a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/a18_str.py
@@ -9,5 +9,13 @@ def events_brick_valid_str() -> Literal["events_brick_valid"]:
     return "events_brick_valid"
 
 
-def vow_event_time_agg_str() -> str:
+# def vow_acct_nets_str() -> Literal["vow_acct_nets"]:
+#     return "vow_acct_nets"
+
+
+def vow_event_time_agg_str() -> Literal["vow_event_time_agg"]:
     return "vow_event_time_agg"
+
+
+# def vow_kpi001_acct_nets_str() -> Literal["vow_kpi001_acct_nets"]:
+#     return "vow_kpi001_acct_nets"

--- a/src/a18_etl_toolbox/_test_util/test_a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/test_a18_str.py
@@ -1,6 +1,7 @@
 from src.a18_etl_toolbox._test_util.a18_str import (
     events_brick_agg_str,
     events_brick_valid_str,
+    vow_event_time_agg_str,
 )
 
 
@@ -9,3 +10,4 @@ def test_str_functions_ReturnsObj():
 
     assert events_brick_agg_str() == "events_brick_agg"
     assert events_brick_valid_str() == "events_brick_valid"
+    assert vow_event_time_agg_str() == "vow_event_time_agg"

--- a/src/a18_etl_toolbox/_test_util/test_a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/test_a18_str.py
@@ -1,4 +1,4 @@
-from src.a18_etl_toolbox._test_util.a18_str import (
+from src.a18_etl_toolbox._test_util.a18_str import (  # vow_acct_nets_str,; vow_kpi001_acct_netsvow_acct_nets_str_str,
     events_brick_agg_str,
     events_brick_valid_str,
     vow_event_time_agg_str,
@@ -11,3 +11,5 @@ def test_str_functions_ReturnsObj():
     assert events_brick_agg_str() == "events_brick_agg"
     assert events_brick_valid_str() == "events_brick_valid"
     assert vow_event_time_agg_str() == "vow_event_time_agg"
+    # assert vow_acct_nets_str() == "vow_acct_nets"
+    # assert vow_kpi001_acct_nets_str() == "vow_kpi001_acct_nets"

--- a/src/a18_etl_toolbox/_test_util/test_a18_str.py
+++ b/src/a18_etl_toolbox/_test_util/test_a18_str.py
@@ -1,0 +1,11 @@
+from src.a18_etl_toolbox._test_util.a18_str import (
+    events_brick_agg_str,
+    events_brick_valid_str,
+)
+
+
+def test_str_functions_ReturnsObj():
+    # ESTABLISH / WHEN / THEN
+
+    assert events_brick_agg_str() == "events_brick_agg"
+    assert events_brick_valid_str() == "events_brick_valid"

--- a/src/a18_etl_toolbox/test_/test_tran_sqlstrs_.py
+++ b/src/a18_etl_toolbox/test_/test_tran_sqlstrs_.py
@@ -25,7 +25,7 @@ from src.a06_plan_logic._test_util.a06_str import (
 from src.a08_plan_atom_logic.atom_config import get_delete_key_name
 from src.a09_pack_logic._test_util.a09_str import event_int_str
 from src.a10_plan_calc._test_util.a10_str import plan_groupunit_str
-from src.a12_hub_tools._test_util.a12_str import job_str
+from src.a12_hub_tools._test_util.a12_str import job_str, vow_ote1_agg_str
 from src.a15_vow_logic._test_util.a15_str import (
     vow_dealunit_str,
     vow_paybook_str,
@@ -48,6 +48,7 @@ from src.a17_idea_logic.idea_db_tool import (
     get_default_sorted_list,
     get_idea_into_dimen_raw_query,
 )
+from src.a18_etl_toolbox._test_util.a18_str import vow_event_time_agg_str
 from src.a18_etl_toolbox.tran_sqlstrs import (
     ALL_DIMEN_ABBV7,
     CREATE_VOW_EVENT_TIME_AGG_SQLSTR,
@@ -313,7 +314,7 @@ def test_IDEA_STAGEBLE_DEL_DIMENS_HasAll_idea_numbersForAll_dimens():
 def test_CREATE_VOW_EVENT_TIME_AGG_SQLSTR_Exists():
     # ESTABLISH
     expected_create_table_sqlstr = f"""
-CREATE TABLE IF NOT EXISTS vow_event_time_agg (
+CREATE TABLE IF NOT EXISTS {vow_event_time_agg_str()} (
   {vow_label_str()} TEXT
 , {event_int_str()} INTEGER
 , agg_time INTEGER
@@ -328,7 +329,7 @@ CREATE TABLE IF NOT EXISTS vow_event_time_agg (
 def test_INSERT_VOW_EVENT_TIME_AGG_SQLSTR_Exists():
     # ESTABLISH
     expected_INSERT_sqlstr = f"""
-INSERT INTO vow_event_time_agg ({vow_label_str()}, {event_int_str()}, agg_time)
+INSERT INTO {vow_event_time_agg_str()} ({vow_label_str()}, {event_int_str()}, agg_time)
 SELECT {vow_label_str()}, {event_int_str()}, agg_time
 FROM (
     SELECT {vow_label_str()}, {event_int_str()}, {tran_time_str()} as agg_time
@@ -352,18 +353,18 @@ def test_UPDATE_ERROR_MESSAGE_VOW_EVENT_TIME_AGG_SQLSTR_Exists():
 WITH EventTimeOrdered AS (
     SELECT {vow_label_str()}, {event_int_str()}, agg_time,
            LAG(agg_time) OVER (PARTITION BY {vow_label_str()} ORDER BY {event_int_str()}) AS prev_agg_time
-    FROM vow_event_time_agg
+    FROM {vow_event_time_agg_str()}
 )
-UPDATE vow_event_time_agg
+UPDATE {vow_event_time_agg_str()}
 SET error_message = CASE 
          WHEN EventTimeOrdered.prev_agg_time > EventTimeOrdered.agg_time
          THEN 'not sorted'
          ELSE 'sorted'
        END 
 FROM EventTimeOrdered
-WHERE EventTimeOrdered.{event_int_str()} = vow_event_time_agg.{event_int_str()}
-    AND EventTimeOrdered.{vow_label_str()} = vow_event_time_agg.{vow_label_str()}
-    AND EventTimeOrdered.agg_time = vow_event_time_agg.agg_time
+WHERE EventTimeOrdered.{event_int_str()} = {vow_event_time_agg_str()}.{event_int_str()}
+    AND EventTimeOrdered.{vow_label_str()} = {vow_event_time_agg_str()}.{vow_label_str()}
+    AND EventTimeOrdered.agg_time = {vow_event_time_agg_str()}.agg_time
 ;
 """
     # WHEN / THEN
@@ -373,7 +374,7 @@ WHERE EventTimeOrdered.{event_int_str()} = vow_event_time_agg.{event_int_str()}
 def test_CREATE_VOW_OTE1_AGG_SQLSTR_Exists():
     # ESTABLISH
     expected_create_table_sqlstr = f"""
-CREATE TABLE IF NOT EXISTS vow_ote1_agg (
+CREATE TABLE IF NOT EXISTS {vow_ote1_agg_str()} (
   {vow_label_str()} TEXT
 , {owner_name_str()} TEXT
 , {event_int_str()} INTEGER
@@ -392,7 +393,7 @@ def test_INSERT_VOW_OTE1_AGG_FROM_VOICE_SQLSTR_Exists():
     # ESTABLISH
     fisdeal_v_raw_tablename = create_prime_tablename(vow_dealunit_str(), "v", "raw")
     expected_INSERT_sqlstr = f"""
-INSERT INTO vow_ote1_agg ({vow_label_str()}, {owner_name_str()}, {event_int_str()}, {deal_time_str()})
+INSERT INTO {vow_ote1_agg_str()} ({vow_label_str()}, {owner_name_str()}, {event_int_str()}, {deal_time_str()})
 SELECT {vow_label_str()}, {owner_name_str()}, {event_int_str()}, {deal_time_str()}
 FROM (
     SELECT 

--- a/src/a18_etl_toolbox/test_/test_tran_sqlstrs_prime.py
+++ b/src/a18_etl_toolbox/test_/test_tran_sqlstrs_prime.py
@@ -305,7 +305,7 @@ def create_plan_voice_del_agg_table_sqlstr(x_dimen: str) -> str:
     return get_create_table_sqlstr(tablename, columns, get_idea_sqlite_types())
 
 
-def test_get_prime_create_table_sqlstrs_ReturnsObj_CheckPidginDimens():
+def test_get_prime_create_table_sqlstrs_ReturnsObj_PidginDimensCheck():
     # sourcery skip: no-loop-in-tests
     # ESTABLISH / WHEN
     create_table_sqlstrs = get_prime_create_table_sqlstrs()
@@ -339,7 +339,7 @@ def test_get_prime_create_table_sqlstrs_ReturnsObj_CheckPidginDimens():
         assert expected_s_vld_sqlstr == create_table_sqlstrs.get(s_vld_tablename)
 
 
-def test_get_prime_create_table_sqlstrs_ReturnsObj_CheckPidginCoreDimens():
+def test_get_prime_create_table_sqlstrs_ReturnsObj_PidginCoreDimensPidgin():
     # ESTABLISH / WHEN
     create_table_sqlstrs = get_prime_create_table_sqlstrs()
 

--- a/src/a18_etl_toolbox/test_tran/test_brick_raw_tables_to_events_brick_table.py
+++ b/src/a18_etl_toolbox/test_tran/test_brick_raw_tables_to_events_brick_table.py
@@ -9,6 +9,10 @@ from src.a09_pack_logic._test_util.a09_str import event_int_str, face_name_str
 from src.a15_vow_logic._test_util.a15_str import cumlative_minute_str, hour_label_str
 from src.a17_idea_logic._test_util.a17_str import brick_agg_str, idea_number_str
 from src.a17_idea_logic.idea_db_tool import create_idea_sorted_table
+from src.a18_etl_toolbox._test_util.a18_str import (
+    events_brick_agg_str,
+    events_brick_valid_str,
+)
 from src.a18_etl_toolbox.transformers import (
     etl_brick_raw_tables_to_events_brick_agg_table,
     etl_events_brick_agg_db_to_event_dict,
@@ -56,7 +60,7 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        brick_events_tablename = "events_brick_agg"
+        brick_events_tablename = events_brick_agg_str()
         assert get_row_count(cursor, agg_br00003_tablename) == 4
         assert not db_table_exists(cursor, brick_events_tablename)
 
@@ -131,7 +135,7 @@ VALUES
 """
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
-        brick_events_tablename = "events_brick_agg"
+        brick_events_tablename = events_brick_agg_str()
         assert get_row_count(cursor, agg_br00003_tablename) == 5
         assert not db_table_exists(cursor, brick_events_tablename)
 
@@ -171,8 +175,13 @@ def test_etl_events_brick_agg_table_to_events_brick_valid_table_PopulatesTables_
     event9 = 9
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        agg_events_tablename = "events_brick_agg"
-        agg_events_columns = ["idea_number", "event_int", "face_name", "error_message"]
+        agg_events_tablename = events_brick_agg_str()
+        agg_events_columns = [
+            idea_number_str(),
+            event_int_str(),
+            face_name_str(),
+            "error_message",
+        ]
         create_idea_sorted_table(cursor, agg_events_tablename, agg_events_columns)
         insert_into_clause = f"""INSERT INTO {agg_events_tablename} (
   {idea_number_str()}
@@ -192,7 +201,7 @@ VALUES
         insert_sqlstr = f"{insert_into_clause} {values_clause}"
         cursor.execute(insert_sqlstr)
         assert get_row_count(cursor, agg_events_tablename) == 4
-        valid_events_tablename = "events_brick_valid"
+        valid_events_tablename = events_brick_valid_str()
         assert not db_table_exists(cursor, valid_events_tablename)
 
         # WHEN
@@ -227,7 +236,7 @@ def test_etl_events_brick_agg_db_to_event_dict_ReturnsObj_Scenario0():
     agg_columns = [face_name_str(), event_int_str(), "error_message"]
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
-        agg_events_tablename = "events_brick_agg"
+        agg_events_tablename = events_brick_agg_str()
         create_idea_sorted_table(cursor, agg_events_tablename, agg_columns)
         insert_into_clause = f"""
 INSERT INTO {agg_events_tablename} ({event_int_str()}, {face_name_str()}, error_message)

--- a/src/a18_etl_toolbox/test_tran/test_voice_agg_tables_to_vow_jsons.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_agg_tables_to_vow_jsons.py
@@ -23,6 +23,7 @@ from src.a18_etl_toolbox._test_util.a18_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,
 )
+from src.a18_etl_toolbox._test_util.a18_str import vow_event_time_agg_str
 from src.a18_etl_toolbox.tran_sqlstrs import (
     create_prime_tablename,
     get_dimen_abbv7,
@@ -136,8 +137,7 @@ VALUES ('{accord23_str}'), ('{accord45_str}')
 """
         cursor.execute(insert_raw_sqlstr)
         assert get_row_count(cursor, fisunit_v_agg_tablename) == 2
-        vow_event_time_agg_str = "vow_event_time_agg"
-        assert db_table_exists(cursor, vow_event_time_agg_str) is False
+        assert db_table_exists(cursor, vow_event_time_agg_str()) is False
 
         accord23_json_path = create_vow_json_path(vow_mstr_dir, accord23_str)
         accord45_json_path = create_vow_json_path(vow_mstr_dir, accord45_str)

--- a/src/a18_etl_toolbox/test_tran/test_voice_agg_tables_to_vow_ote1_agg.py
+++ b/src/a18_etl_toolbox/test_tran/test_voice_agg_tables_to_vow_ote1_agg.py
@@ -6,6 +6,7 @@ from src.a02_finance_logic._test_util.a02_str import (
     vow_label_str,
 )
 from src.a09_pack_logic._test_util.a09_str import event_int_str
+from src.a12_hub_tools._test_util.a12_str import vow_ote1_agg_str
 from src.a15_vow_logic._test_util.a15_str import vow_dealunit_str
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
 from src.a18_etl_toolbox.transformers import (
@@ -41,16 +42,15 @@ VALUES
 """
         cursor.execute(insert_raw_sqlstr)
         assert get_row_count(cursor, fisdeal_v_raw_table) == 4
-        vow_ote1_agg_str = "vow_ote1_agg"
-        assert db_table_exists(cursor, vow_ote1_agg_str) is False
+        assert db_table_exists(cursor, vow_ote1_agg_str()) is False
 
         # WHEN
         etl_voice_raw_tables_to_vow_ote1_agg(cursor)
 
         # THEN
-        assert db_table_exists(cursor, vow_ote1_agg_str)
-        assert get_row_count(cursor, vow_ote1_agg_str) == 3
-        cursor.execute(f"SELECT * FROM {vow_ote1_agg_str};")
+        assert db_table_exists(cursor, vow_ote1_agg_str())
+        assert get_row_count(cursor, vow_ote1_agg_str()) == 3
+        cursor.execute(f"SELECT * FROM {vow_ote1_agg_str()};")
         vowunit_agg_rows = cursor.fetchall()
         ex_row0 = (accord23_str, bob_str, event3, timepoint55, None)
         ex_row1 = (accord45_str, sue_str, event3, timepoint55, None)

--- a/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
@@ -28,6 +28,7 @@ from src.a17_idea_logic.idea_db_tool import upsert_sheet
 from src.a18_etl_toolbox._test_util.a18_str import (
     events_brick_agg_str,
     events_brick_valid_str,
+    vow_event_time_agg_str,
 )
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
 from src.a19_world_logic._test_util.a19_env import (
@@ -68,7 +69,6 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
     br00113_agg = f"{br00113_str}_brick_agg"
     br00113_valid = f"{br00113_str}_brick_valid"
     events_brick_valid_tablename = events_brick_valid_str()
-    vow_event_time_agg_tablename = "vow_event_time_agg"
     pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
     pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
     pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
@@ -128,7 +128,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
         assert not os_path_exists(a23_e1_expressed_pack_path)
         assert not os_path_exists(a23_sue_gut_path)
         assert not os_path_exists(a23_sue_job_path)
-        assert not db_table_exists(cursor, vow_event_time_agg_tablename)
+        assert not db_table_exists(cursor, vow_event_time_agg_str())
         assert not db_table_exists(cursor, vow_ote1_agg_str())
         assert not db_table_exists(cursor, planacct_job)
 
@@ -186,7 +186,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
         assert os_path_exists(a23_sue_gut_path)
         assert os_path_exists(a23_sue_job_path)
         assert get_row_count(cursor, planacct_job) == 1
-        # assert get_row_count(cursor, vow_event_time_agg_tablename) == 0
+        # assert get_row_count(cursor, vow_event_time_agg_str()) == 0
         # assert get_row_count(cursor, vow_ote1_agg_tablename) == 0
 
 
@@ -342,155 +342,155 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         assert os_path_exists(sue37_mandate_path)
 
 
-def test_WorldUnit_mud_to_clarity_with_cursor_Scenario2_PopulateVowTranBook(
-    env_dir_setup_cleanup,
-):
-    # ESTABLISH:
-    fizz_str = "fizz"
-    fizz_world = worldunit_shop(fizz_str, worlds_dir())
-    # delete_dir(fizz_world.worlds_dir)
-    sue_str = "Sue"
-    sue_inx = "Suzy"
-    e3 = 3
-    ex_filename = "fizzbuzz.xlsx"
-    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
-    br00113_columns = [
-        face_name_str(),
-        event_int_str(),
-        vow_label_str(),
-        owner_name_str(),
-        acct_name_str(),
-        otx_name_str(),
-        inx_name_str(),
-    ]
-    a23_str = "accord23"
-    br00113_str = "br00113"
-    br00113row0 = [sue_str, e3, a23_str, sue_str, sue_str, sue_str, sue_inx]
-    br00113_df = DataFrame([br00113row0], columns=br00113_columns)
-    br00113_ex0_str = f"example0_{br00113_str}"
-    upsert_sheet(mud_file_path, br00113_ex0_str, br00113_df)
+# def test_WorldUnit_mud_to_clarity_with_cursor_Scenario2_PopulateVowTranBook(
+#     env_dir_setup_cleanup,
+# ):
+#     # ESTABLISH:
+#     fizz_str = "fizz"
+#     fizz_world = worldunit_shop(fizz_str, worlds_dir())
+#     # delete_dir(fizz_world.worlds_dir)
+#     sue_str = "Sue"
+#     sue_inx = "Suzy"
+#     e3 = 3
+#     ex_filename = "fizzbuzz.xlsx"
+#     mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+#     br00113_columns = [
+#         face_name_str(),
+#         event_int_str(),
+#         vow_label_str(),
+#         owner_name_str(),
+#         acct_name_str(),
+#         otx_name_str(),
+#         inx_name_str(),
+#     ]
+#     a23_str = "accord23"
+#     br00113_str = "br00113"
+#     br00113row0 = [sue_str, e3, a23_str, sue_str, sue_str, sue_str, sue_inx]
+#     br00113_df = DataFrame([br00113row0], columns=br00113_columns)
+#     br00113_ex0_str = f"example0_{br00113_str}"
+#     upsert_sheet(mud_file_path, br00113_ex0_str, br00113_df)
 
-    br00001_columns = [
-        event_int_str(),
-        face_name_str(),
-        vow_label_str(),
-        owner_name_str(),
-        deal_time_str(),
-        quota_str(),
-        celldepth_str(),
-    ]
-    tp37 = 37
-    sue_quota = 235
-    sue_celldepth = 3
-    br1row0 = [e3, sue_str, a23_str, sue_str, tp37, sue_quota, sue_celldepth]
-    br00001_1df = DataFrame([br1row0], columns=br00001_columns)
-    br00001_ex0_str = "example0_br00001"
-    upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
+#     br00001_columns = [
+#         event_int_str(),
+#         face_name_str(),
+#         vow_label_str(),
+#         owner_name_str(),
+#         deal_time_str(),
+#         quota_str(),
+#         celldepth_str(),
+#     ]
+#     tp37 = 37
+#     sue_quota = 235
+#     sue_celldepth = 3
+#     br1row0 = [e3, sue_str, a23_str, sue_str, tp37, sue_quota, sue_celldepth]
+#     br00001_1df = DataFrame([br1row0], columns=br00001_columns)
+#     br00001_ex0_str = "example0_br00001"
+#     upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
 
-    # Names of tables
-    br00113_raw = f"{br00113_str}_brick_raw"
-    br00113_agg = f"{br00113_str}_brick_agg"
-    br00113_valid = f"{br00113_str}_brick_valid"
-    events_brick_valid_tablename = events_brick_valid_str()
-    pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
-    pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
-    pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
-    pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
-    pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
-    pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
-    fisunit_sound_raw = create_prime_tablename("fisunit", "s", "raw")
-    fisunit_sound_agg = create_prime_tablename("fisunit", "s", "agg")
-    planunit_sound_put_raw = create_prime_tablename("planunit", "s", "raw", "put")
-    planunit_sound_put_agg = create_prime_tablename("planunit", "s", "agg", "put")
-    planacct_sound_put_raw = create_prime_tablename("planacct", "s", "raw", "put")
-    planacct_sound_put_agg = create_prime_tablename("planacct", "s", "agg", "put")
-    fisunit_voice_raw = create_prime_tablename("fisunit", "v", "raw")
-    fisunit_voice_agg = create_prime_tablename("fisunit", "v", "agg")
-    planunit_voice_put_raw = create_prime_tablename("planunit", "v", "raw", "put")
-    planunit_voice_put_agg = create_prime_tablename("planunit", "v", "agg", "put")
-    planacct_voice_put_raw = create_prime_tablename("planacct", "v", "raw", "put")
-    planacct_voice_put_agg = create_prime_tablename("planacct", "v", "agg", "put")
-    mstr_dir = fizz_world._vow_mstr_dir
-    a23_json_path = create_vow_json_path(mstr_dir, a23_str)
-    a23_e1_all_pack_path = create_event_all_pack_path(mstr_dir, a23_str, sue_inx, e3)
-    a23_e1_expressed_pack_path = expressed_path(mstr_dir, a23_str, sue_inx, e3)
-    a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_inx)
-    a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_inx)
-    sue37_mandate_path = deal_mandate(mstr_dir, a23_str, sue_inx, tp37)
+#     # Names of tables
+#     br00113_raw = f"{br00113_str}_brick_raw"
+#     br00113_agg = f"{br00113_str}_brick_agg"
+#     br00113_valid = f"{br00113_str}_brick_valid"
+#     events_brick_valid_tablename = events_brick_valid_str()
+#     pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
+#     pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
+#     pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
+#     pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
+#     pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
+#     pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
+#     fisunit_sound_raw = create_prime_tablename("fisunit", "s", "raw")
+#     fisunit_sound_agg = create_prime_tablename("fisunit", "s", "agg")
+#     planunit_sound_put_raw = create_prime_tablename("planunit", "s", "raw", "put")
+#     planunit_sound_put_agg = create_prime_tablename("planunit", "s", "agg", "put")
+#     planacct_sound_put_raw = create_prime_tablename("planacct", "s", "raw", "put")
+#     planacct_sound_put_agg = create_prime_tablename("planacct", "s", "agg", "put")
+#     fisunit_voice_raw = create_prime_tablename("fisunit", "v", "raw")
+#     fisunit_voice_agg = create_prime_tablename("fisunit", "v", "agg")
+#     planunit_voice_put_raw = create_prime_tablename("planunit", "v", "raw", "put")
+#     planunit_voice_put_agg = create_prime_tablename("planunit", "v", "agg", "put")
+#     planacct_voice_put_raw = create_prime_tablename("planacct", "v", "raw", "put")
+#     planacct_voice_put_agg = create_prime_tablename("planacct", "v", "agg", "put")
+#     mstr_dir = fizz_world._vow_mstr_dir
+#     a23_json_path = create_vow_json_path(mstr_dir, a23_str)
+#     a23_e1_all_pack_path = create_event_all_pack_path(mstr_dir, a23_str, sue_inx, e3)
+#     a23_e1_expressed_pack_path = expressed_path(mstr_dir, a23_str, sue_inx, e3)
+#     a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_inx)
+#     a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_inx)
+#     sue37_mandate_path = deal_mandate(mstr_dir, a23_str, sue_inx, tp37)
 
-    with sqlite3_connect(":memory:") as db_conn:
-        cursor = db_conn.cursor()
-        assert not db_table_exists(cursor, br00113_raw)
-        assert not db_table_exists(cursor, br00113_agg)
-        assert not db_table_exists(cursor, events_brick_agg_str())
-        assert not db_table_exists(cursor, events_brick_valid_tablename)
-        assert not db_table_exists(cursor, br00113_valid)
-        assert not db_table_exists(cursor, pidname_sound_raw)
-        assert not db_table_exists(cursor, pidname_sound_agg)
-        assert not db_table_exists(cursor, fisunit_sound_raw)
-        assert not db_table_exists(cursor, fisunit_sound_agg)
-        assert not db_table_exists(cursor, planunit_sound_put_raw)
-        assert not db_table_exists(cursor, planunit_sound_put_agg)
-        assert not db_table_exists(cursor, pidcore_sound_raw)
-        assert not db_table_exists(cursor, pidcore_sound_agg)
-        assert not db_table_exists(cursor, pidcore_sound_vld)
-        assert not db_table_exists(cursor, pidname_sound_vld)
-        assert not db_table_exists(cursor, fisunit_voice_raw)
-        assert not db_table_exists(cursor, fisunit_voice_agg)
-        assert not db_table_exists(cursor, planunit_voice_put_raw)
-        assert not db_table_exists(cursor, planunit_voice_put_agg)
-        assert not db_table_exists(cursor, planacct_voice_put_raw)
-        assert not db_table_exists(cursor, planacct_voice_put_agg)
-        assert not os_path_exists(a23_json_path)
-        assert not os_path_exists(a23_e1_all_pack_path)
-        assert not os_path_exists(a23_e1_expressed_pack_path)
-        assert not os_path_exists(a23_sue_gut_path)
-        assert not os_path_exists(a23_sue_job_path)
-        assert not db_table_exists(cursor, vow_ote1_agg_str())
-        assert not os_path_exists(sue37_mandate_path)
-        # self.vow_agg_tables_to_vow_ote1_agg(cursor)
+#     with sqlite3_connect(":memory:") as db_conn:
+#         cursor = db_conn.cursor()
+#         assert not db_table_exists(cursor, br00113_raw)
+#         assert not db_table_exists(cursor, br00113_agg)
+#         assert not db_table_exists(cursor, events_brick_agg_str())
+#         assert not db_table_exists(cursor, events_brick_valid_tablename)
+#         assert not db_table_exists(cursor, br00113_valid)
+#         assert not db_table_exists(cursor, pidname_sound_raw)
+#         assert not db_table_exists(cursor, pidname_sound_agg)
+#         assert not db_table_exists(cursor, fisunit_sound_raw)
+#         assert not db_table_exists(cursor, fisunit_sound_agg)
+#         assert not db_table_exists(cursor, planunit_sound_put_raw)
+#         assert not db_table_exists(cursor, planunit_sound_put_agg)
+#         assert not db_table_exists(cursor, pidcore_sound_raw)
+#         assert not db_table_exists(cursor, pidcore_sound_agg)
+#         assert not db_table_exists(cursor, pidcore_sound_vld)
+#         assert not db_table_exists(cursor, pidname_sound_vld)
+#         assert not db_table_exists(cursor, fisunit_voice_raw)
+#         assert not db_table_exists(cursor, fisunit_voice_agg)
+#         assert not db_table_exists(cursor, planunit_voice_put_raw)
+#         assert not db_table_exists(cursor, planunit_voice_put_agg)
+#         assert not db_table_exists(cursor, planacct_voice_put_raw)
+#         assert not db_table_exists(cursor, planacct_voice_put_agg)
+#         assert not os_path_exists(a23_json_path)
+#         assert not os_path_exists(a23_e1_all_pack_path)
+#         assert not os_path_exists(a23_e1_expressed_pack_path)
+#         assert not os_path_exists(a23_sue_gut_path)
+#         assert not os_path_exists(a23_sue_job_path)
+#         assert not db_table_exists(cursor, vow_ote1_agg_str())
+#         assert not os_path_exists(sue37_mandate_path)
+#         # self.vow_agg_tables_to_vow_ote1_agg(cursor)
 
-        # # create planunits
-        # self.plan_tables_to_event_plan_csvs(cursor)
+#         # # create planunits
+#         # self.plan_tables_to_event_plan_csvs(cursor)
 
-        # # create all vow_job and mandate reports
-        # self.calc_vow_deal_acct_mandate_net_ledgers()
+#         # # create all vow_job and mandate reports
+#         # self.calc_vow_deal_acct_mandate_net_ledgers()
 
-        # WHEN
-        fizz_world.mud_to_clarity_with_cursor(db_conn, cursor)
+#         # WHEN
+#         fizz_world.mud_to_clarity_with_cursor(db_conn, cursor)
 
-        # THEN
-        assert get_row_count(cursor, br00113_raw) == 1
-        assert get_row_count(cursor, br00113_agg) == 1
-        assert get_row_count(cursor, events_brick_agg_str()) == 2
-        assert get_row_count(cursor, events_brick_valid_tablename) == 2
-        assert get_row_count(cursor, br00113_valid) == 2
-        assert get_row_count(cursor, pidname_sound_raw) == 2
-        assert get_row_count(cursor, fisunit_sound_raw) == 4
-        assert get_row_count(cursor, planunit_sound_put_raw) == 4
-        assert get_row_count(cursor, planacct_sound_put_raw) == 2
-        assert get_row_count(cursor, pidname_sound_agg) == 1
-        assert get_row_count(cursor, fisunit_sound_agg) == 1
-        assert get_row_count(cursor, planunit_sound_put_agg) == 1
-        assert get_row_count(cursor, planacct_sound_put_agg) == 1
-        assert get_row_count(cursor, pidcore_sound_raw) == 1
-        assert get_row_count(cursor, pidcore_sound_agg) == 1
-        assert get_row_count(cursor, pidcore_sound_vld) == 1
-        assert get_row_count(cursor, pidname_sound_vld) == 1
-        assert get_row_count(cursor, fisunit_voice_raw) == 1
-        assert get_row_count(cursor, planunit_voice_put_raw) == 1
-        assert get_row_count(cursor, planacct_voice_put_raw) == 1
-        assert get_row_count(cursor, fisunit_voice_agg) == 1
-        assert get_row_count(cursor, planunit_voice_put_agg) == 1
-        assert get_row_count(cursor, planacct_voice_put_agg) == 1
-        assert os_path_exists(a23_json_path)
-        assert os_path_exists(a23_e1_all_pack_path)
-        assert os_path_exists(a23_e1_expressed_pack_path)
-        assert os_path_exists(a23_sue_gut_path)
-        assert os_path_exists(a23_sue_job_path)
-        assert get_row_count(cursor, vow_ote1_agg_str()) == 1
-        print(f"{sue37_mandate_path=}")
-        assert os_path_exists(sue37_mandate_path)
+#         # THEN
+#         assert get_row_count(cursor, br00113_raw) == 1
+#         assert get_row_count(cursor, br00113_agg) == 1
+#         assert get_row_count(cursor, events_brick_agg_str()) == 2
+#         assert get_row_count(cursor, events_brick_valid_tablename) == 2
+#         assert get_row_count(cursor, br00113_valid) == 2
+#         assert get_row_count(cursor, pidname_sound_raw) == 2
+#         assert get_row_count(cursor, fisunit_sound_raw) == 4
+#         assert get_row_count(cursor, planunit_sound_put_raw) == 4
+#         assert get_row_count(cursor, planacct_sound_put_raw) == 2
+#         assert get_row_count(cursor, pidname_sound_agg) == 1
+#         assert get_row_count(cursor, fisunit_sound_agg) == 1
+#         assert get_row_count(cursor, planunit_sound_put_agg) == 1
+#         assert get_row_count(cursor, planacct_sound_put_agg) == 1
+#         assert get_row_count(cursor, pidcore_sound_raw) == 1
+#         assert get_row_count(cursor, pidcore_sound_agg) == 1
+#         assert get_row_count(cursor, pidcore_sound_vld) == 1
+#         assert get_row_count(cursor, pidname_sound_vld) == 1
+#         assert get_row_count(cursor, fisunit_voice_raw) == 1
+#         assert get_row_count(cursor, planunit_voice_put_raw) == 1
+#         assert get_row_count(cursor, planacct_voice_put_raw) == 1
+#         assert get_row_count(cursor, fisunit_voice_agg) == 1
+#         assert get_row_count(cursor, planunit_voice_put_agg) == 1
+#         assert get_row_count(cursor, planacct_voice_put_agg) == 1
+#         assert os_path_exists(a23_json_path)
+#         assert os_path_exists(a23_e1_all_pack_path)
+#         assert os_path_exists(a23_e1_expressed_pack_path)
+#         assert os_path_exists(a23_sue_gut_path)
+#         assert os_path_exists(a23_sue_job_path)
+#         assert get_row_count(cursor, vow_ote1_agg_str()) == 1
+#         print(f"{sue37_mandate_path=}")
+#         assert os_path_exists(sue37_mandate_path)
 
 
 def test_WorldUnit_mud_to_clarity_with_cursor_Scenario3_WhenNoVowIdeas_ote1_IsStillCreated(

--- a/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
@@ -25,7 +25,7 @@ from src.a12_hub_tools.hub_path import (
 from src.a15_vow_logic._test_util.a15_str import cumlative_minute_str, hour_label_str
 from src.a16_pidgin_logic._test_util.a16_str import inx_name_str, otx_name_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
-from src.a18_etl_toolbox._test_util.a18_str import (
+from src.a18_etl_toolbox._test_util.a18_str import (  # vow_acct_nets_str,; vow_kpi001_acct_nets_str,
     events_brick_agg_str,
     events_brick_valid_str,
     vow_event_time_agg_str,

--- a/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
@@ -341,7 +341,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         assert os_path_exists(sue37_mandate_path)
 
 
-def test_WorldUnit_mud_to_clarity_with_cursor_Senario1_WhenNoVowIdeas_ote1_IsStillCreated(
+def test_WorldUnit_mud_to_clarity_with_cursor_Scenario3_WhenNoVowIdeas_ote1_IsStillCreated(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -375,7 +375,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Senario1_WhenNoVowIdeas_ote1_IsSti
     assert os_path_exists(a23_ote1_csv_path)
 
 
-def test_WorldUnit_mud_to_clarity_with_cursor_Scenario2_DeletesPreviousFiles(
+def test_WorldUnit_mud_to_clarity_with_cursor_Scenario4_DeletesPreviousFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH
@@ -404,7 +404,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario2_DeletesPreviousFiles(
     assert os_path_exists(testing3_path) is False
 
 
-def test_WorldUnit_mud_to_clarity_with_cursor_Scenario3_CreatesFiles(
+def test_WorldUnit_mud_to_clarity_with_cursor_Scenario5_CreatesFiles(
     env_dir_setup_cleanup,
 ):
     # ESTABLISH

--- a/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
+++ b/src/a19_world_logic/test_etl_pipeline/test_mud_to_stances.py
@@ -12,6 +12,7 @@ from src.a02_finance_logic._test_util.a02_str import (
 )
 from src.a06_plan_logic._test_util.a06_str import acct_name_str
 from src.a09_pack_logic._test_util.a09_str import event_int_str, face_name_str
+from src.a12_hub_tools._test_util.a12_str import vow_ote1_agg_str
 from src.a12_hub_tools.hub_path import (
     create_deal_acct_mandate_ledger_path as deal_mandate,
     create_event_all_pack_path,
@@ -24,6 +25,10 @@ from src.a12_hub_tools.hub_path import (
 from src.a15_vow_logic._test_util.a15_str import cumlative_minute_str, hour_label_str
 from src.a16_pidgin_logic._test_util.a16_str import inx_name_str, otx_name_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
+from src.a18_etl_toolbox._test_util.a18_str import (
+    events_brick_agg_str,
+    events_brick_valid_str,
+)
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
 from src.a19_world_logic._test_util.a19_env import (
     env_dir_setup_cleanup,
@@ -62,10 +67,8 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
     br00113_raw = f"{br00113_str}_brick_raw"
     br00113_agg = f"{br00113_str}_brick_agg"
     br00113_valid = f"{br00113_str}_brick_valid"
-    events_brick_agg_tablename = "events_brick_agg"
-    events_brick_valid_tablename = "events_brick_valid"
+    events_brick_valid_tablename = events_brick_valid_str()
     vow_event_time_agg_tablename = "vow_event_time_agg"
-    vow_ote1_agg_tablename = "vow_ote1_agg"
     pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
     pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
     pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
@@ -99,7 +102,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
         cursor = db_conn.cursor()
         assert not db_table_exists(cursor, br00113_raw)
         assert not db_table_exists(cursor, br00113_agg)
-        assert not db_table_exists(cursor, events_brick_agg_tablename)
+        assert not db_table_exists(cursor, events_brick_agg_str())
         assert not db_table_exists(cursor, events_brick_valid_tablename)
         assert not db_table_exists(cursor, br00113_valid)
         assert not db_table_exists(cursor, pidname_sound_raw)
@@ -126,7 +129,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
         assert not os_path_exists(a23_sue_gut_path)
         assert not os_path_exists(a23_sue_job_path)
         assert not db_table_exists(cursor, vow_event_time_agg_tablename)
-        assert not db_table_exists(cursor, vow_ote1_agg_tablename)
+        assert not db_table_exists(cursor, vow_ote1_agg_str())
         assert not db_table_exists(cursor, planacct_job)
 
         # # create planunits
@@ -152,7 +155,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario0_br000113PopulatesTables(
 
         assert get_row_count(cursor, br00113_raw) == 1
         assert get_row_count(cursor, br00113_agg) == 1
-        assert get_row_count(cursor, events_brick_agg_tablename) == 1
+        assert get_row_count(cursor, events_brick_agg_str()) == 1
         assert get_row_count(cursor, events_brick_valid_tablename) == 1
         assert get_row_count(cursor, br00113_valid) == 1
         assert get_row_count(cursor, pidname_sound_raw) == 1
@@ -237,9 +240,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
     br00113_raw = f"{br00113_str}_brick_raw"
     br00113_agg = f"{br00113_str}_brick_agg"
     br00113_valid = f"{br00113_str}_brick_valid"
-    events_brick_agg_tablename = "events_brick_agg"
-    events_brick_valid_tablename = "events_brick_valid"
-    vow_ote1_agg_tablename = "vow_ote1_agg"
+    events_brick_valid_tablename = events_brick_valid_str()
     pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
     pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
     pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
@@ -270,7 +271,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         cursor = db_conn.cursor()
         assert not db_table_exists(cursor, br00113_raw)
         assert not db_table_exists(cursor, br00113_agg)
-        assert not db_table_exists(cursor, events_brick_agg_tablename)
+        assert not db_table_exists(cursor, events_brick_agg_str())
         assert not db_table_exists(cursor, events_brick_valid_tablename)
         assert not db_table_exists(cursor, br00113_valid)
         assert not db_table_exists(cursor, pidname_sound_raw)
@@ -294,7 +295,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         assert not os_path_exists(a23_e1_expressed_pack_path)
         assert not os_path_exists(a23_sue_gut_path)
         assert not os_path_exists(a23_sue_job_path)
-        assert not db_table_exists(cursor, vow_ote1_agg_tablename)
+        assert not db_table_exists(cursor, vow_ote1_agg_str())
         assert not os_path_exists(sue37_mandate_path)
         # self.vow_agg_tables_to_vow_ote1_agg(cursor)
 
@@ -310,7 +311,7 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         # THEN
         assert get_row_count(cursor, br00113_raw) == 1
         assert get_row_count(cursor, br00113_agg) == 1
-        assert get_row_count(cursor, events_brick_agg_tablename) == 2
+        assert get_row_count(cursor, events_brick_agg_str()) == 2
         assert get_row_count(cursor, events_brick_valid_tablename) == 2
         assert get_row_count(cursor, br00113_valid) == 2
         assert get_row_count(cursor, pidname_sound_raw) == 2
@@ -336,7 +337,158 @@ def test_WorldUnit_mud_to_clarity_with_cursor_Scenario1_PopulateDealPayRows(
         assert os_path_exists(a23_e1_expressed_pack_path)
         assert os_path_exists(a23_sue_gut_path)
         assert os_path_exists(a23_sue_job_path)
-        assert get_row_count(cursor, vow_ote1_agg_tablename) == 1
+        assert get_row_count(cursor, vow_ote1_agg_str()) == 1
+        print(f"{sue37_mandate_path=}")
+        assert os_path_exists(sue37_mandate_path)
+
+
+def test_WorldUnit_mud_to_clarity_with_cursor_Scenario2_PopulateVowTranBook(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH:
+    fizz_str = "fizz"
+    fizz_world = worldunit_shop(fizz_str, worlds_dir())
+    # delete_dir(fizz_world.worlds_dir)
+    sue_str = "Sue"
+    sue_inx = "Suzy"
+    e3 = 3
+    ex_filename = "fizzbuzz.xlsx"
+    mud_file_path = create_path(fizz_world._mud_dir, ex_filename)
+    br00113_columns = [
+        face_name_str(),
+        event_int_str(),
+        vow_label_str(),
+        owner_name_str(),
+        acct_name_str(),
+        otx_name_str(),
+        inx_name_str(),
+    ]
+    a23_str = "accord23"
+    br00113_str = "br00113"
+    br00113row0 = [sue_str, e3, a23_str, sue_str, sue_str, sue_str, sue_inx]
+    br00113_df = DataFrame([br00113row0], columns=br00113_columns)
+    br00113_ex0_str = f"example0_{br00113_str}"
+    upsert_sheet(mud_file_path, br00113_ex0_str, br00113_df)
+
+    br00001_columns = [
+        event_int_str(),
+        face_name_str(),
+        vow_label_str(),
+        owner_name_str(),
+        deal_time_str(),
+        quota_str(),
+        celldepth_str(),
+    ]
+    tp37 = 37
+    sue_quota = 235
+    sue_celldepth = 3
+    br1row0 = [e3, sue_str, a23_str, sue_str, tp37, sue_quota, sue_celldepth]
+    br00001_1df = DataFrame([br1row0], columns=br00001_columns)
+    br00001_ex0_str = "example0_br00001"
+    upsert_sheet(mud_file_path, br00001_ex0_str, br00001_1df)
+
+    # Names of tables
+    br00113_raw = f"{br00113_str}_brick_raw"
+    br00113_agg = f"{br00113_str}_brick_agg"
+    br00113_valid = f"{br00113_str}_brick_valid"
+    events_brick_valid_tablename = events_brick_valid_str()
+    pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
+    pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
+    pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
+    pidcore_sound_raw = create_prime_tablename("pidcore", "s", "raw")
+    pidcore_sound_agg = create_prime_tablename("pidcore", "s", "agg")
+    pidcore_sound_vld = create_prime_tablename("pidcore", "s", "vld")
+    fisunit_sound_raw = create_prime_tablename("fisunit", "s", "raw")
+    fisunit_sound_agg = create_prime_tablename("fisunit", "s", "agg")
+    planunit_sound_put_raw = create_prime_tablename("planunit", "s", "raw", "put")
+    planunit_sound_put_agg = create_prime_tablename("planunit", "s", "agg", "put")
+    planacct_sound_put_raw = create_prime_tablename("planacct", "s", "raw", "put")
+    planacct_sound_put_agg = create_prime_tablename("planacct", "s", "agg", "put")
+    fisunit_voice_raw = create_prime_tablename("fisunit", "v", "raw")
+    fisunit_voice_agg = create_prime_tablename("fisunit", "v", "agg")
+    planunit_voice_put_raw = create_prime_tablename("planunit", "v", "raw", "put")
+    planunit_voice_put_agg = create_prime_tablename("planunit", "v", "agg", "put")
+    planacct_voice_put_raw = create_prime_tablename("planacct", "v", "raw", "put")
+    planacct_voice_put_agg = create_prime_tablename("planacct", "v", "agg", "put")
+    mstr_dir = fizz_world._vow_mstr_dir
+    a23_json_path = create_vow_json_path(mstr_dir, a23_str)
+    a23_e1_all_pack_path = create_event_all_pack_path(mstr_dir, a23_str, sue_inx, e3)
+    a23_e1_expressed_pack_path = expressed_path(mstr_dir, a23_str, sue_inx, e3)
+    a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_inx)
+    a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_inx)
+    sue37_mandate_path = deal_mandate(mstr_dir, a23_str, sue_inx, tp37)
+
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        assert not db_table_exists(cursor, br00113_raw)
+        assert not db_table_exists(cursor, br00113_agg)
+        assert not db_table_exists(cursor, events_brick_agg_str())
+        assert not db_table_exists(cursor, events_brick_valid_tablename)
+        assert not db_table_exists(cursor, br00113_valid)
+        assert not db_table_exists(cursor, pidname_sound_raw)
+        assert not db_table_exists(cursor, pidname_sound_agg)
+        assert not db_table_exists(cursor, fisunit_sound_raw)
+        assert not db_table_exists(cursor, fisunit_sound_agg)
+        assert not db_table_exists(cursor, planunit_sound_put_raw)
+        assert not db_table_exists(cursor, planunit_sound_put_agg)
+        assert not db_table_exists(cursor, pidcore_sound_raw)
+        assert not db_table_exists(cursor, pidcore_sound_agg)
+        assert not db_table_exists(cursor, pidcore_sound_vld)
+        assert not db_table_exists(cursor, pidname_sound_vld)
+        assert not db_table_exists(cursor, fisunit_voice_raw)
+        assert not db_table_exists(cursor, fisunit_voice_agg)
+        assert not db_table_exists(cursor, planunit_voice_put_raw)
+        assert not db_table_exists(cursor, planunit_voice_put_agg)
+        assert not db_table_exists(cursor, planacct_voice_put_raw)
+        assert not db_table_exists(cursor, planacct_voice_put_agg)
+        assert not os_path_exists(a23_json_path)
+        assert not os_path_exists(a23_e1_all_pack_path)
+        assert not os_path_exists(a23_e1_expressed_pack_path)
+        assert not os_path_exists(a23_sue_gut_path)
+        assert not os_path_exists(a23_sue_job_path)
+        assert not db_table_exists(cursor, vow_ote1_agg_str())
+        assert not os_path_exists(sue37_mandate_path)
+        # self.vow_agg_tables_to_vow_ote1_agg(cursor)
+
+        # # create planunits
+        # self.plan_tables_to_event_plan_csvs(cursor)
+
+        # # create all vow_job and mandate reports
+        # self.calc_vow_deal_acct_mandate_net_ledgers()
+
+        # WHEN
+        fizz_world.mud_to_clarity_with_cursor(db_conn, cursor)
+
+        # THEN
+        assert get_row_count(cursor, br00113_raw) == 1
+        assert get_row_count(cursor, br00113_agg) == 1
+        assert get_row_count(cursor, events_brick_agg_str()) == 2
+        assert get_row_count(cursor, events_brick_valid_tablename) == 2
+        assert get_row_count(cursor, br00113_valid) == 2
+        assert get_row_count(cursor, pidname_sound_raw) == 2
+        assert get_row_count(cursor, fisunit_sound_raw) == 4
+        assert get_row_count(cursor, planunit_sound_put_raw) == 4
+        assert get_row_count(cursor, planacct_sound_put_raw) == 2
+        assert get_row_count(cursor, pidname_sound_agg) == 1
+        assert get_row_count(cursor, fisunit_sound_agg) == 1
+        assert get_row_count(cursor, planunit_sound_put_agg) == 1
+        assert get_row_count(cursor, planacct_sound_put_agg) == 1
+        assert get_row_count(cursor, pidcore_sound_raw) == 1
+        assert get_row_count(cursor, pidcore_sound_agg) == 1
+        assert get_row_count(cursor, pidcore_sound_vld) == 1
+        assert get_row_count(cursor, pidname_sound_vld) == 1
+        assert get_row_count(cursor, fisunit_voice_raw) == 1
+        assert get_row_count(cursor, planunit_voice_put_raw) == 1
+        assert get_row_count(cursor, planacct_voice_put_raw) == 1
+        assert get_row_count(cursor, fisunit_voice_agg) == 1
+        assert get_row_count(cursor, planunit_voice_put_agg) == 1
+        assert get_row_count(cursor, planacct_voice_put_agg) == 1
+        assert os_path_exists(a23_json_path)
+        assert os_path_exists(a23_e1_all_pack_path)
+        assert os_path_exists(a23_e1_expressed_pack_path)
+        assert os_path_exists(a23_sue_gut_path)
+        assert os_path_exists(a23_sue_job_path)
+        assert get_row_count(cursor, vow_ote1_agg_str()) == 1
         print(f"{sue37_mandate_path=}")
         assert os_path_exists(sue37_mandate_path)
 
@@ -550,9 +702,7 @@ def test_WorldUnit_mud_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         br00113_raw = f"{br00113_str}_brick_raw"
         br00113_agg = f"{br00113_str}_brick_agg"
         br00113_valid = f"{br00113_str}_brick_valid"
-        events_brick_agg_tablename = "events_brick_agg"
-        events_brick_valid_tablename = "events_brick_valid"
-        vow_ote1_agg_tablename = "vow_ote1_agg"
+        events_brick_valid_tablename = events_brick_valid_str()
         pidname_sound_raw = create_prime_tablename("pidname", "s", "raw")
         pidname_sound_agg = create_prime_tablename("pidname", "s", "agg")
         pidname_sound_vld = create_prime_tablename("pidname", "s", "vld")
@@ -575,7 +725,7 @@ def test_WorldUnit_mud_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         cursor = db_conn.cursor()
         assert get_row_count(cursor, br00113_raw) == 1
         assert get_row_count(cursor, br00113_agg) == 1
-        assert get_row_count(cursor, events_brick_agg_tablename) == 2
+        assert get_row_count(cursor, events_brick_agg_str()) == 2
         assert get_row_count(cursor, events_brick_valid_tablename) == 2
         assert get_row_count(cursor, br00113_valid) == 2
         assert get_row_count(cursor, pidname_sound_raw) == 2
@@ -596,4 +746,4 @@ def test_WorldUnit_mud_to_clarity_mstr_Scenario0_CreatesDatabaseFile(
         assert get_row_count(cursor, fisunit_voice_agg) == 1
         assert get_row_count(cursor, planunit_voice_put_agg) == 1
         assert get_row_count(cursor, planacct_voice_put_agg) == 1
-        assert get_row_count(cursor, vow_ote1_agg_tablename) == 1
+        assert get_row_count(cursor, vow_ote1_agg_str()) == 1

--- a/src/a19_world_logic/world.py
+++ b/src/a19_world_logic/world.py
@@ -4,15 +4,10 @@ from sqlite3 import (
     Cursor as sqlite3_Cursor,
     connect as sqlite3_connect,
 )
-from src.a00_data_toolbox.dict_toolbox import (
-    get_0_if_None,
-    get_empty_dict_if_None,
-    get_empty_set_if_None,
-)
+from src.a00_data_toolbox.dict_toolbox import get_0_if_None, get_empty_set_if_None
 from src.a00_data_toolbox.file_toolbox import create_path, delete_dir, set_dir
 from src.a01_term_logic.term import EventInt, FaceName, VowLabel
 from src.a02_finance_logic.deal import TimeLinePoint
-from src.a07_calendar_logic.chrono import TimeLineLabel
 from src.a15_vow_logic.vow import VowUnit
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (


### PR DESCRIPTION
## Summary by Sourcery

Introduce centralized string literal helper functions for table and column names across the codebase and tests, replacing hard-coded string literals, updating documentation, example data frames, and test cases to use these helpers, and apply a minor variable renaming refactor in the group_logic module.

Enhancements:
- Add string-helper functions (e.g., events_brick_agg_str, events_brick_valid_str, vow_event_time_agg_str, vow_ote1_agg_str, job_listen_rotations_str) in test utility packages
- Replace hard-coded table and column name literals in tests and DataFrame examples with calls to the new string-helper functions
- Rename loop variables in set_credor_pool and set_debtor_pool to a consistent name in a03_group_logic.acct

Documentation:
- Update str_funcs.md to list the new string-helper functions for ETL toolbox and vow logic

Tests:
- Extend and adjust existing tests to assert the new string-helper functions return the correct literals
- Rename scenario numbers and test functions for consistency and cover string utilities in test suites