### PR TITLE
812 create cli tool for executing mud to clarity etl

### DIFF
--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -13,13 +13,13 @@
 - a09_pack_logic: event_int, face_name
 - a10_believer_calc: believer_groupunit, jmetrics
 - a11_bud_logic: amount, believeradjust, believerevent_facts, boss_facts, bud_believer_name, bud_person_nets, bud_time, celldepth, found_facts, offi_time, quota, tran_time
-- a12_hub_toolbox: belief_mstr_dir, belief_ote1_agg, gut, job
+- a12_hub_toolbox: belief_mstr_dir, gut, job
 - a13_believer_listen_logic: 
 - a14_keep_logic: 
 - a15_belief_logic: belief_budunit, belief_paybook, belief_timeline_hour, belief_timeline_month, belief_timeline_weekday, belief_timeoffi, beliefunit, brokerunits, cumulative_minute, hour_label, job_listen_rotations, month_label, paybook, weekday_label, weekday_order
 - a16_pidgin_logic: inx_knot, inx_label, inx_name, inx_rope, inx_title, map_otx2inx, otx2inx, otx_key, otx_knot, otx_label, otx_name, otx_rope, otx_title, pidgin_core, pidgin_label, pidgin_name, pidgin_rope, pidgin_title, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, build_order, delete_insert, delete_insert_update, delete_update, error_message, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, world_name
-- a18_etl_toolbox: belief_event_time_agg, belief_person_nets, believer_net_amount, brick_agg, brick_raw, brick_valid, events_brick_agg, events_brick_valid, sound_agg, sound_raw, voice_agg, voice_raw
+- a18_etl_toolbox: belief_event_time_agg, belief_ote1_agg, belief_person_nets, believer_net_amount, brick_agg, brick_raw, brick_valid, events_brick_agg, events_brick_valid, sound_agg, sound_raw, voice_agg, voice_raw
 - a19_kpi_toolbox: belief_kpi001_person_nets
 - a20_world_logic: 
 - a21_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/src/a12_hub_toolbox/a12_path.py
+++ b/src/a12_hub_toolbox/a12_path.py
@@ -5,7 +5,6 @@ BELIEF_FILENAME = "belief.json"
 BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
 BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
 BUDUNIT_FILENAME = "budunit.json"
-BUD_MANDATE_FILENAME = "bud_person_mandate_ledger.json"
 CELLNODE_FILENAME = "cell.json"
 CELL_MANDATE_FILENAME = "cell_person_mandate_ledger.json"
 BELIEVERPOINT_FILENAME = "believerpoint.json"
@@ -131,19 +130,6 @@ def create_budunit_json_path(
         belief_mstr_dir, belief_label, believer_name, bud_time
     )
     return create_path(timepoint_dir, "budunit.json")
-
-
-def create_bud_person_mandate_ledger_path(
-    belief_mstr_dir: str,
-    belief_label: LabelTerm,
-    believer_name: BelieverName,
-    bud_time: int,
-) -> str:
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\buds\n\\bud_time\\bud_person_mandate_ledger.json"""
-    timepoint_dir = create_bud_dir_path(
-        belief_mstr_dir, belief_label, believer_name, bud_time
-    )
-    return create_path(timepoint_dir, "bud_person_mandate_ledger.json")
 
 
 def create_believerpoint_path(

--- a/src/a12_hub_toolbox/a12_path.py
+++ b/src/a12_hub_toolbox/a12_path.py
@@ -2,8 +2,6 @@ from src.a00_data_toolbox.file_toolbox import create_path
 from src.a01_term_logic.term import BelieverName, LabelTerm
 
 BELIEF_FILENAME = "belief.json"
-BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
-BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
 BUDUNIT_FILENAME = "budunit.json"
 CELLNODE_FILENAME = "cell.json"
 CELL_MANDATE_FILENAME = "cell_person_mandate_ledger.json"
@@ -28,20 +26,6 @@ def create_belief_json_path(belief_mstr_dir: str, belief_label: LabelTerm) -> st
     beliefs_dir = create_path(belief_mstr_dir, "beliefs")
     belief_path = create_path(beliefs_dir, belief_label)
     return create_path(belief_path, "belief.json")
-
-
-def create_belief_ote1_csv_path(belief_mstr_dir: str, belief_label: LabelTerm):
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.csv"""
-    beliefs_dir = create_path(belief_mstr_dir, "beliefs")
-    belief_path = create_path(beliefs_dir, belief_label)
-    return create_path(belief_path, "belief_ote1_agg.csv")
-
-
-def create_belief_ote1_json_path(belief_mstr_dir: str, belief_label: LabelTerm):
-    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.json"""
-    beliefs_dir = create_path(belief_mstr_dir, "beliefs")
-    belief_path = create_path(beliefs_dir, belief_label)
-    return create_path(belief_path, "belief_ote1_agg.json")
 
 
 def create_belief_believers_dir_path(

--- a/src/a12_hub_toolbox/hubunit.py
+++ b/src/a12_hub_toolbox/hubunit.py
@@ -348,7 +348,7 @@ class HubUnit:
         set_dir(self.keep_path())
 
     def treasury_db_path(self) -> str:
-        "Returns path: keep_path/treasury.db" ""
+        "Returns path: keep_path/treasury.db"
 
         return create_path(self.keep_path(), treasury_filename())
 

--- a/src/a12_hub_toolbox/test/_util/a12_str.py
+++ b/src/a12_hub_toolbox/test/_util/a12_str.py
@@ -5,10 +5,6 @@ def belief_mstr_dir_str() -> str:
     return "belief_mstr_dir"
 
 
-def belief_ote1_agg_str() -> Literal["belief_ote1_agg"]:
-    return "belief_ote1_agg"
-
-
 def gut_str() -> Literal["gut"]:
     return "gut"
 

--- a/src/a12_hub_toolbox/test/_util/test_a12_path.py
+++ b/src/a12_hub_toolbox/test/_util/test_a12_path.py
@@ -13,7 +13,6 @@ from src.a12_hub_toolbox.a12_path import (
     BELIEF_OTE1_AGG_JSON_FILENAME,
     BELIEVEREVENT_FILENAME,
     BELIEVERPOINT_FILENAME,
-    BUD_MANDATE_FILENAME,
     BUDUNIT_FILENAME,
     CELL_MANDATE_FILENAME,
     CELLNODE_FILENAME,
@@ -30,7 +29,6 @@ from src.a12_hub_toolbox.a12_path import (
     create_believerevent_path,
     create_believerpoint_path,
     create_bud_dir_path,
-    create_bud_person_mandate_ledger_path,
     create_buds_dir_path,
     create_budunit_json_path,
     create_cell_dir_path,
@@ -257,29 +255,6 @@ def test_create_budunit_json_path_ReturnsObj():
     buds_dir = create_path(sue_dir, "buds")
     timepoint_dir = create_path(buds_dir, timepoint7)
     expected_bud_path_dir = create_path(timepoint_dir, BUDUNIT_FILENAME)
-    assert gen_bud_path == expected_bud_path_dir
-
-
-def test_create_bud_person_mandate_ledger_path_ReturnsObj():
-    # ESTABLISH
-    x_belief_mstr_dir = get_module_temp_dir()
-    a23_str = "amy23"
-    sue_str = "Sue"
-    timepoint7 = 7
-
-    # WHEN
-    gen_bud_path = create_bud_person_mandate_ledger_path(
-        x_belief_mstr_dir, a23_str, sue_str, timepoint7
-    )
-
-    # THEN
-    x_beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
-    amy23_dir = create_path(x_beliefs_dir, a23_str)
-    believers_dir = create_path(amy23_dir, "believers")
-    sue_dir = create_path(believers_dir, sue_str)
-    buds_dir = create_path(sue_dir, "buds")
-    timepoint_dir = create_path(buds_dir, timepoint7)
-    expected_bud_path_dir = create_path(timepoint_dir, BUD_MANDATE_FILENAME)
     assert gen_bud_path == expected_bud_path_dir
 
 
@@ -758,20 +733,6 @@ def test_create_budunit_json_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_budunit_json_path) == doc_str
-
-
-def test_create_bud_person_mandate_ledger_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_bud_person_mandate_ledger_path(
-        belief_mstr_dir="belief_mstr_dir",
-        belief_label=belief_label_str(),
-        believer_name=believer_name_str(),
-        bud_time=bud_time_str(),
-    )
-    doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
-    doc_str = f"Returns path: {doc_str}"
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_bud_person_mandate_ledger_path) == doc_str
 
 
 def test_create_believerpoint_path_HasDocString():

--- a/src/a12_hub_toolbox/test/_util/test_a12_path.py
+++ b/src/a12_hub_toolbox/test/_util/test_a12_path.py
@@ -9,8 +9,6 @@ from src.a09_pack_logic.test._util.a09_str import (
 )
 from src.a12_hub_toolbox.a12_path import (
     BELIEF_FILENAME,
-    BELIEF_OTE1_AGG_CSV_FILENAME,
-    BELIEF_OTE1_AGG_JSON_FILENAME,
     BELIEVEREVENT_FILENAME,
     BELIEVERPOINT_FILENAME,
     BUDUNIT_FILENAME,
@@ -22,8 +20,6 @@ from src.a12_hub_toolbox.a12_path import (
     create_belief_believers_dir_path,
     create_belief_dir_path,
     create_belief_json_path,
-    create_belief_ote1_csv_path,
-    create_belief_ote1_json_path,
     create_believer_dir_path,
     create_believer_event_dir_path,
     create_believerevent_path,
@@ -77,36 +73,6 @@ def test_create_belief_json_path_ReturnsObj():
     a23_path = create_path(beliefs_dir, a23_str)
     expected_a23_json_path = create_path(a23_path, BELIEF_FILENAME)
     assert gen_a23_json_path == expected_a23_json_path
-
-
-def test_create_belief_ote1_csv_path_ReturnsObj():
-    # ESTABLISH
-    x_belief_mstr_dir = get_module_temp_dir()
-    a23_str = "amy23"
-
-    # WHEN
-    gen_a23_te_csv_path = create_belief_ote1_csv_path(x_belief_mstr_dir, a23_str)
-
-    # THEN
-    beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
-    a23_path = create_path(beliefs_dir, a23_str)
-    expected_a23_te_path = create_path(a23_path, BELIEF_OTE1_AGG_CSV_FILENAME)
-    assert gen_a23_te_csv_path == expected_a23_te_path
-
-
-def test_create_belief_ote1_json_path_ReturnsObj():
-    # ESTABLISH
-    x_belief_mstr_dir = get_module_temp_dir()
-    a23_str = "amy23"
-
-    # WHEN
-    gen_a23_te_csv_path = create_belief_ote1_json_path(x_belief_mstr_dir, a23_str)
-
-    # THEN
-    beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
-    a23_path = create_path(beliefs_dir, a23_str)
-    expected_a23_te_path = create_path(a23_path, BELIEF_OTE1_AGG_JSON_FILENAME)
-    assert gen_a23_te_csv_path == expected_a23_te_path
 
 
 def test_create_belief_believers_dir_path_ReturnsObj():
@@ -567,26 +533,6 @@ def test_create_belief_json_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_belief_json_path) == doc_str
-
-
-def test_create_belief_ote1_csv_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_belief_ote1_csv_path(
-        "belief_mstr_dir", belief_label=belief_label_str()
-    )
-    doc_str = f"Returns path: {doc_str}"
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_belief_ote1_csv_path) == doc_str
-
-
-def test_create_belief_ote1_json_path_HasDocString():
-    # ESTABLISH
-    doc_str = create_belief_ote1_json_path(
-        "belief_mstr_dir", belief_label=belief_label_str()
-    )
-    doc_str = f"Returns path: {doc_str}"
-    # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_belief_ote1_json_path) == doc_str
 
 
 def test_create_belief_believers_dir_path_HasDocString():

--- a/src/a12_hub_toolbox/test/_util/test_a12_str.py
+++ b/src/a12_hub_toolbox/test/_util/test_a12_str.py
@@ -1,14 +1,8 @@
-from src.a12_hub_toolbox.test._util.a12_str import (
-    belief_mstr_dir_str,
-    belief_ote1_agg_str,
-    gut_str,
-    job_str,
-)
+from src.a12_hub_toolbox.test._util.a12_str import belief_mstr_dir_str, gut_str, job_str
 
 
 def test_str_functions_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert gut_str() == "gut"
     assert job_str() == "job"
-    assert belief_ote1_agg_str() == "belief_ote1_agg"
     assert belief_mstr_dir_str() == "belief_mstr_dir"

--- a/src/a15_belief_logic/a15_path.py
+++ b/src/a15_belief_logic/a15_path.py
@@ -1,0 +1,18 @@
+from src.a00_data_toolbox.file_toolbox import create_path
+from src.a01_term_logic.term import BelieverName, LabelTerm
+from src.a12_hub_toolbox.a12_path import create_bud_dir_path
+
+BUD_MANDATE_FILENAME = "bud_person_mandate_ledger.json"
+
+
+def create_bud_person_mandate_ledger_path(
+    belief_mstr_dir: str,
+    belief_label: LabelTerm,
+    believer_name: BelieverName,
+    bud_time: int,
+) -> str:
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\believers\\believer_name\\buds\n\\bud_time\\bud_person_mandate_ledger.json"""
+    timepoint_dir = create_bud_dir_path(
+        belief_mstr_dir, belief_label, believer_name, bud_time
+    )
+    return create_path(timepoint_dir, "bud_person_mandate_ledger.json")

--- a/src/a15_belief_logic/belief.py
+++ b/src/a15_belief_logic/belief.py
@@ -425,7 +425,7 @@ class BeliefUnit:
 def _get_ote1_max_past_event_int(
     believer_name: str, ote1_dict: dict[str, dict[str, int]], bud_time: int
 ) -> EventInt:
-    """Using the belief_ote1_agg grab most recent event int before a given bud_time"""
+    """Using the grab most recent ote1 event int before a given bud_time"""
     ote1_believer_dict = ote1_dict.get(believer_name)
     if not ote1_believer_dict:
         return None

--- a/src/a15_belief_logic/belief_cell.py
+++ b/src/a15_belief_logic/belief_cell.py
@@ -15,7 +15,6 @@ from src.a04_reason_logic.reason_plan import get_dict_from_factunits
 from src.a11_bud_logic.bud import BeliefLabel
 from src.a11_bud_logic.cell import CellUnit, cellunit_shop
 from src.a12_hub_toolbox.a12_path import (
-    BUD_MANDATE_FILENAME,
     CELL_MANDATE_FILENAME,
     CELLNODE_FILENAME,
     create_belief_json_path,
@@ -34,6 +33,7 @@ from src.a12_hub_toolbox.hub_tool import (
     get_believers_downhill_event_ints,
     open_believer_file,
 )
+from src.a15_belief_logic.a15_path import BUD_MANDATE_FILENAME
 from src.a15_belief_logic.belief import get_from_dict as beliefunit_get_from_dict
 
 

--- a/src/a15_belief_logic/test/_util/test_a15_path.py
+++ b/src/a15_belief_logic/test/_util/test_a15_path.py
@@ -1,0 +1,53 @@
+from inspect import getdoc as inspect_getdoc
+from platform import system as platform_system
+from src.a00_data_toolbox.file_toolbox import create_path
+from src.a09_pack_logic.test._util.a09_str import (
+    belief_label_str,
+    believer_name_str,
+    bud_time_str,
+)
+from src.a12_hub_toolbox.test._util.a12_env import get_module_temp_dir
+from src.a15_belief_logic.a15_path import (
+    BUD_MANDATE_FILENAME,
+    create_bud_person_mandate_ledger_path,
+)
+
+
+def test_create_bud_person_mandate_ledger_path_ReturnsObj():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+    a23_str = "amy23"
+    sue_str = "Sue"
+    timepoint7 = 7
+
+    # WHEN
+    gen_bud_path = create_bud_person_mandate_ledger_path(
+        x_belief_mstr_dir, a23_str, sue_str, timepoint7
+    )
+
+    # THEN
+    x_beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
+    amy23_dir = create_path(x_beliefs_dir, a23_str)
+    believers_dir = create_path(amy23_dir, "believers")
+    sue_dir = create_path(believers_dir, sue_str)
+    buds_dir = create_path(sue_dir, "buds")
+    timepoint_dir = create_path(buds_dir, timepoint7)
+    expected_bud_path_dir = create_path(timepoint_dir, BUD_MANDATE_FILENAME)
+    assert gen_bud_path == expected_bud_path_dir
+
+
+LINUX_OS = platform_system() == "Linux"
+
+
+def test_create_bud_person_mandate_ledger_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_bud_person_mandate_ledger_path(
+        belief_mstr_dir="belief_mstr_dir",
+        belief_label=belief_label_str(),
+        believer_name=believer_name_str(),
+        bud_time=bud_time_str(),
+    )
+    doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_bud_person_mandate_ledger_path) == doc_str

--- a/src/a15_belief_logic/test/test_belief_z_cell/test_bud_mandates.py
+++ b/src/a15_belief_logic/test/test_belief_z_cell/test_bud_mandates.py
@@ -3,8 +3,10 @@ from src.a00_data_toolbox.file_toolbox import open_json, save_json
 from src.a11_bud_logic.bud import tranbook_shop
 from src.a12_hub_toolbox.a12_path import (
     create_belief_json_path,
-    create_bud_person_mandate_ledger_path as bud_mandate_path,
     create_cell_person_mandate_ledger_path as cell_mandate_path,
+)
+from src.a15_belief_logic.a15_path import (
+    create_bud_person_mandate_ledger_path as bud_mandate_path,
 )
 from src.a15_belief_logic.belief import (
     beliefunit_shop,

--- a/src/a18_etl_toolbox/a18_path.py
+++ b/src/a18_etl_toolbox/a18_path.py
@@ -4,6 +4,12 @@ from src.a01_term_logic.term import BelieverName, LabelTerm
 STANCE0001_FILENAME = "stance0001.xlsx"
 BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
 BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
+LAST_RUN_METRICS_JSON_FILENAME = "last_run_metrics.json"
+
+
+def create_last_run_metrics_path(belief_mstr_dir: str):
+    """Returns path: belief_mstr_dir\\last_run_metrics.json"""
+    return create_path(belief_mstr_dir, LAST_RUN_METRICS_JSON_FILENAME)
 
 
 def create_belief_ote1_csv_path(belief_mstr_dir: str, belief_label: LabelTerm):

--- a/src/a18_etl_toolbox/a18_path.py
+++ b/src/a18_etl_toolbox/a18_path.py
@@ -1,7 +1,23 @@
 from src.a00_data_toolbox.file_toolbox import create_path
-from src.a01_term_logic.term import BelieverName
+from src.a01_term_logic.term import BelieverName, LabelTerm
 
 STANCE0001_FILENAME = "stance0001.xlsx"
+BELIEF_OTE1_AGG_CSV_FILENAME = "belief_ote1_agg.csv"
+BELIEF_OTE1_AGG_JSON_FILENAME = "belief_ote1_agg.json"
+
+
+def create_belief_ote1_csv_path(belief_mstr_dir: str, belief_label: LabelTerm):
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.csv"""
+    beliefs_dir = create_path(belief_mstr_dir, "beliefs")
+    belief_path = create_path(beliefs_dir, belief_label)
+    return create_path(belief_path, "belief_ote1_agg.csv")
+
+
+def create_belief_ote1_json_path(belief_mstr_dir: str, belief_label: LabelTerm):
+    """Returns path: belief_mstr_dir\\beliefs\\belief_label\\belief_ote1_agg.json"""
+    beliefs_dir = create_path(belief_mstr_dir, "beliefs")
+    belief_path = create_path(beliefs_dir, belief_label)
+    return create_path(belief_path, "belief_ote1_agg.json")
 
 
 def create_stances_dir_path(belief_mstr_dir: str) -> str:

--- a/src/a18_etl_toolbox/stance_tool.py
+++ b/src/a18_etl_toolbox/stance_tool.py
@@ -144,7 +144,7 @@ ORDER BY
 
 def add_pidgin_rows_to_stance_csv_strs(
     cursor: sqlite3_Cursor, belief_csv_strs: dict[str, str], csv_delimiter: str
-) -> str:
+):
     br00042_csv = belief_csv_strs.get("br00042")
     br00043_csv = belief_csv_strs.get("br00043")
     br00044_csv = belief_csv_strs.get("br00044")

--- a/src/a18_etl_toolbox/test/_util/a18_str.py
+++ b/src/a18_etl_toolbox/test/_util/a18_str.py
@@ -6,6 +6,10 @@ def belief_event_time_agg_str() -> Literal["belief_event_time_agg"]:
     return "belief_event_time_agg"
 
 
+def belief_ote1_agg_str() -> Literal["belief_ote1_agg"]:
+    return "belief_ote1_agg"
+
+
 def belief_person_nets_str() -> Literal["belief_person_nets"]:
     """Table name for the account net amounts."""
     return "belief_person_nets"

--- a/src/a18_etl_toolbox/test/_util/test_a18_path.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_path.py
@@ -6,9 +6,11 @@ from src.a09_pack_logic.test._util.a09_str import believer_name_str
 from src.a18_etl_toolbox.a18_path import (
     BELIEF_OTE1_AGG_CSV_FILENAME,
     BELIEF_OTE1_AGG_JSON_FILENAME,
+    LAST_RUN_METRICS_JSON_FILENAME,
     STANCE0001_FILENAME,
     create_belief_ote1_csv_path,
     create_belief_ote1_json_path,
+    create_last_run_metrics_path,
     create_stance0001_path,
     create_stances_believer_dir_path,
     create_stances_dir_path,
@@ -19,9 +21,24 @@ from src.a18_etl_toolbox.test._util.a18_env import (
 )
 
 
-def test_hub_path_constants_are_values():
+def test_a18_path_constants_are_values():
     # ESTABLISH / WHEN / THEN
+    assert BELIEF_OTE1_AGG_CSV_FILENAME == "belief_ote1_agg.csv"
+    assert BELIEF_OTE1_AGG_JSON_FILENAME == "belief_ote1_agg.json"
+    assert LAST_RUN_METRICS_JSON_FILENAME == "last_run_metrics.json"
     assert STANCE0001_FILENAME == "stance0001.xlsx"
+
+
+def test_create_last_run_metrics_path_ReturnsObj():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+
+    # WHEN
+    gen_last_run_metrics_path = create_last_run_metrics_path(x_belief_mstr_dir)
+
+    # THEN
+    expected_path = create_path(x_belief_mstr_dir, LAST_RUN_METRICS_JSON_FILENAME)
+    assert gen_last_run_metrics_path == expected_path
 
 
 def test_create_stances_dir_path_ReturnsObj():
@@ -63,6 +80,14 @@ def test_create_stance0001_path_ReturnsObj():
 
 
 LINUX_OS = platform_system() == "Linux"
+
+
+def test_create_last_run_metrics_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_last_run_metrics_path("belief_mstr_dir")
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_last_run_metrics_path) == doc_str
 
 
 def test_create_stances_dir_path_HasDocString():

--- a/src/a18_etl_toolbox/test/_util/test_a18_path.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_path.py
@@ -1,9 +1,14 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
 from src.a00_data_toolbox.file_toolbox import create_path
+from src.a04_reason_logic.test._util.a04_str import belief_label_str
 from src.a09_pack_logic.test._util.a09_str import believer_name_str
 from src.a18_etl_toolbox.a18_path import (
+    BELIEF_OTE1_AGG_CSV_FILENAME,
+    BELIEF_OTE1_AGG_JSON_FILENAME,
     STANCE0001_FILENAME,
+    create_belief_ote1_csv_path,
+    create_belief_ote1_json_path,
     create_stance0001_path,
     create_stances_believer_dir_path,
     create_stances_dir_path,
@@ -84,3 +89,53 @@ def test_create_stance0001_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
     assert LINUX_OS or inspect_getdoc(create_stance0001_path) == doc_str
+
+
+def test_create_belief_ote1_csv_path_ReturnsObj():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+    a23_str = "amy23"
+
+    # WHEN
+    gen_a23_te_csv_path = create_belief_ote1_csv_path(x_belief_mstr_dir, a23_str)
+
+    # THEN
+    beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
+    a23_path = create_path(beliefs_dir, a23_str)
+    expected_a23_te_path = create_path(a23_path, BELIEF_OTE1_AGG_CSV_FILENAME)
+    assert gen_a23_te_csv_path == expected_a23_te_path
+
+
+def test_create_belief_ote1_json_path_ReturnsObj():
+    # ESTABLISH
+    x_belief_mstr_dir = get_module_temp_dir()
+    a23_str = "amy23"
+
+    # WHEN
+    gen_a23_te_csv_path = create_belief_ote1_json_path(x_belief_mstr_dir, a23_str)
+
+    # THEN
+    beliefs_dir = create_path(x_belief_mstr_dir, "beliefs")
+    a23_path = create_path(beliefs_dir, a23_str)
+    expected_a23_te_path = create_path(a23_path, BELIEF_OTE1_AGG_JSON_FILENAME)
+    assert gen_a23_te_csv_path == expected_a23_te_path
+
+
+def test_create_belief_ote1_csv_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_belief_ote1_csv_path(
+        "belief_mstr_dir", belief_label=belief_label_str()
+    )
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_belief_ote1_csv_path) == doc_str
+
+
+def test_create_belief_ote1_json_path_HasDocString():
+    # ESTABLISH
+    doc_str = create_belief_ote1_json_path(
+        "belief_mstr_dir", belief_label=belief_label_str()
+    )
+    doc_str = f"Returns path: {doc_str}"
+    # WHEN / THEN
+    assert LINUX_OS or inspect_getdoc(create_belief_ote1_json_path) == doc_str

--- a/src/a18_etl_toolbox/test/_util/test_a18_str.py
+++ b/src/a18_etl_toolbox/test/_util/test_a18_str.py
@@ -1,5 +1,6 @@
 from src.a18_etl_toolbox.test._util.a18_str import (
     belief_event_time_agg_str,
+    belief_ote1_agg_str,
     belief_person_nets_str,
     believer_net_amount_str,
     brick_agg_str,
@@ -16,6 +17,7 @@ from src.a18_etl_toolbox.test._util.a18_str import (
 
 def test_str_functions_ReturnsObj():
     # ESTABLISH / WHEN / THEN
+    assert belief_ote1_agg_str() == "belief_ote1_agg"
     assert brick_agg_str() == "brick_agg"
     assert brick_raw_str() == "brick_raw"
     assert brick_valid_str() == "brick_valid"

--- a/src/a18_etl_toolbox/test/test_/test_tran_sqlstrs_.py
+++ b/src/a18_etl_toolbox/test/test_/test_tran_sqlstrs_.py
@@ -26,7 +26,7 @@ from src.a11_bud_logic.test._util.a11_str import (
     bud_time_str,
     tran_time_str,
 )
-from src.a12_hub_toolbox.test._util.a12_str import belief_ote1_agg_str, job_str
+from src.a12_hub_toolbox.test._util.a12_str import job_str
 from src.a15_belief_logic.test._util.a15_str import (
     belief_budunit_str,
     belief_paybook_str,
@@ -55,6 +55,7 @@ from src.a17_idea_logic.idea_db_tool import (
 from src.a17_idea_logic.test._util.a17_str import error_message_str, idea_category_str
 from src.a18_etl_toolbox.test._util.a18_str import (
     belief_event_time_agg_str,
+    belief_ote1_agg_str,
     belief_person_nets_str,
     believer_net_amount_str,
 )

--- a/src/a18_etl_toolbox/test/test_tran/test_belief_believer_time_agg_csv_to_json.py
+++ b/src/a18_etl_toolbox/test/test_tran/test_belief_believer_time_agg_csv_to_json.py
@@ -6,11 +6,11 @@ from src.a11_bud_logic.test._util.a11_str import (
     believer_name_str,
     bud_time_str,
 )
-from src.a12_hub_toolbox.a12_path import (
+from src.a17_idea_logic.test._util.a17_str import error_message_str
+from src.a18_etl_toolbox.a18_path import (
     create_belief_ote1_csv_path,
     create_belief_ote1_json_path,
 )
-from src.a17_idea_logic.test._util.a17_str import error_message_str
 from src.a18_etl_toolbox.test._util.a18_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,

--- a/src/a18_etl_toolbox/test/test_tran/test_brick_raw_tables_to_brick_agg_tables.py
+++ b/src/a18_etl_toolbox/test/test_tran/test_brick_raw_tables_to_brick_agg_tables.py
@@ -234,7 +234,25 @@ ORDER BY {event_int_str()}, {cumulative_minute_str()};"""
         assert rows[1] == row1
 
 
-def test_get_max_brick_events_event_int_ReturnsObj_Scenario0_OneTable():
+def test_get_max_brick_events_event_int_ReturnsObj_Scenario0_NoTables():
+    # ESTABLISH
+    agg_br00003_tablename = f"br00003_{brick_agg_str()}"
+    agg_br00003_columns = [
+        event_int_str(),
+        face_name_str(),
+        belief_label_str(),
+        cumulative_minute_str(),
+        hour_label_str(),
+    ]
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_idea_sorted_table(cursor, agg_br00003_tablename, agg_br00003_columns)
+
+        # WHEN
+        assert get_max_brick_agg_event_int(cursor) == 1
+
+
+def test_get_max_brick_events_event_int_ReturnsObj_Scenario1_OneTable():
     # ESTABLISH
     a23_str = "amy23"
     sue_str = "Sue"
@@ -283,7 +301,7 @@ VALUES
         assert max_event_int == event9
 
 
-def test_get_max_brick_events_event_int_ReturnsObj_Scenario1_MultipleTable():
+def test_get_max_brick_events_event_int_ReturnsObj_Scenario2_MultipleTable():
     # ESTABLISH
     event1 = 1
     event3 = 3

--- a/src/a18_etl_toolbox/test/test_tran/test_create_last_run_metrics_json.py
+++ b/src/a18_etl_toolbox/test/test_tran/test_create_last_run_metrics_json.py
@@ -1,0 +1,62 @@
+from os.path import exists as os_path_exists
+from sqlite3 import connect as sqlite3_connect
+from src.a00_data_toolbox.file_toolbox import open_json
+from src.a09_pack_logic.test._util.a09_str import event_int_str, face_name_str
+from src.a15_belief_logic.test._util.a15_str import (
+    belief_label_str,
+    cumulative_minute_str,
+    hour_label_str,
+)
+from src.a17_idea_logic.idea_db_tool import create_idea_sorted_table
+from src.a18_etl_toolbox.a18_path import create_last_run_metrics_path
+from src.a18_etl_toolbox.test._util.a18_env import get_module_temp_dir
+from src.a18_etl_toolbox.test._util.a18_str import (
+    brick_agg_str,
+    brick_raw_str,
+    error_message_str,
+)
+from src.a18_etl_toolbox.tran_sqlstrs import create_sound_and_voice_tables
+from src.a18_etl_toolbox.transformers import (
+    create_last_run_metrics_json,
+    etl_brick_raw_tables_to_brick_agg_tables,
+    get_max_brick_agg_event_int,
+)
+
+
+def test_create_last_run_metrics_json_CreatesFile():
+    # ESTABLISH
+    event1 = 1
+    event3 = 3
+    event9 = 9
+    belief_mstr_dir = get_module_temp_dir()
+    last_run_metrics_path = create_last_run_metrics_path(belief_mstr_dir)
+    with sqlite3_connect(":memory:") as db_conn:
+        cursor = db_conn.cursor()
+        create_sound_and_voice_tables(cursor)
+        agg_br00003_tablename = f"br00003_{brick_agg_str()}"
+        agg_br00003_columns = [event_int_str()]
+        create_idea_sorted_table(cursor, agg_br00003_tablename, agg_br00003_columns)
+        agg_br00003_insert_sqlstr = f"""
+INSERT INTO {agg_br00003_tablename} ({event_int_str()})
+VALUES ('{event1}'), ('{event1}'), ('{event9}');"""
+        cursor.execute(agg_br00003_insert_sqlstr)
+
+        agg_br00044_tablename = f"br00044_{brick_agg_str()}"
+        agg_br00044_columns = [event_int_str()]
+        create_idea_sorted_table(cursor, agg_br00044_tablename, agg_br00044_columns)
+        agg_br00044_insert_sqlstr = f"""
+INSERT INTO {agg_br00044_tablename} ({event_int_str()})
+VALUES ('{event3}');"""
+        cursor.execute(agg_br00044_insert_sqlstr)
+        assert not os_path_exists(last_run_metrics_path)
+
+        # WHEN
+        create_last_run_metrics_json(cursor, belief_mstr_dir)
+
+        # THEN
+        assert os_path_exists(last_run_metrics_path)
+        last_run_metrics_dict = open_json(last_run_metrics_path)
+        max_brick_agg_event_int_str = "max_brick_agg_event_int"
+        assert max_brick_agg_event_int_str in set(last_run_metrics_dict.keys())
+        max_brick_agg_event_int = last_run_metrics_dict.get(max_brick_agg_event_int_str)
+        assert max_brick_agg_event_int == event9

--- a/src/a18_etl_toolbox/test/test_tran/test_voice_agg_tables_to_belief_ote1_agg.py
+++ b/src/a18_etl_toolbox/test/test_tran/test_voice_agg_tables_to_belief_ote1_agg.py
@@ -6,8 +6,8 @@ from src.a11_bud_logic.test._util.a11_str import (
     believer_name_str,
     bud_time_str,
 )
-from src.a12_hub_toolbox.test._util.a12_str import belief_ote1_agg_str
 from src.a15_belief_logic.test._util.a15_str import belief_budunit_str
+from src.a18_etl_toolbox.test._util.a18_str import belief_ote1_agg_str
 from src.a18_etl_toolbox.tran_sqlstrs import create_prime_tablename
 from src.a18_etl_toolbox.transformers import (
     create_sound_and_voice_tables,

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -36,8 +36,6 @@ from src.a09_pack_logic.pack import PackUnit, get_packunit_from_json, packunit_s
 from src.a11_bud_logic.bud import TranBook
 from src.a12_hub_toolbox.a12_path import (
     create_belief_json_path,
-    create_belief_ote1_csv_path,
-    create_belief_ote1_json_path,
     create_believer_event_dir_path,
     create_believerevent_path,
     create_event_all_pack_path,
@@ -81,6 +79,10 @@ from src.a17_idea_logic.idea_db_tool import (
     create_idea_sorted_table,
     get_default_sorted_list,
     split_excel_into_dirs,
+)
+from src.a18_etl_toolbox.a18_path import (
+    create_belief_ote1_csv_path,
+    create_belief_ote1_json_path,
 )
 from src.a18_etl_toolbox.db_obj_belief_tool import get_belief_dict_from_voice_tables
 from src.a18_etl_toolbox.db_obj_believer_tool import insert_job_obj

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -83,6 +83,7 @@ from src.a17_idea_logic.idea_db_tool import (
 from src.a18_etl_toolbox.a18_path import (
     create_belief_ote1_csv_path,
     create_belief_ote1_json_path,
+    create_last_run_metrics_path,
 )
 from src.a18_etl_toolbox.db_obj_belief_tool import get_belief_dict_from_voice_tables
 from src.a18_etl_toolbox.db_obj_believer_tool import insert_job_obj
@@ -932,3 +933,10 @@ def etl_belief_json_person_nets_to_belief_person_nets_table(
         x_beliefunit = get_default_path_beliefunit(belief_mstr_dir, belief_label)
         x_beliefunit.set_all_tranbook()
         insert_tranunit_persons_net(cursor, x_beliefunit._all_tranbook)
+
+
+def create_last_run_metrics_json(cursor: sqlite3_Cursor, belief_mstr_dir: str):
+    max_brick_agg_event_int = get_max_brick_agg_event_int(cursor)
+    last_run_metrics_path = create_last_run_metrics_path(belief_mstr_dir)
+    last_run_metrics_dict = {"max_brick_agg_event_int": max_brick_agg_event_int}
+    save_json(last_run_metrics_path, None, last_run_metrics_dict)

--- a/src/a18_etl_toolbox/transformers.py
+++ b/src/a18_etl_toolbox/transformers.py
@@ -168,6 +168,8 @@ def get_max_brick_agg_event_int(cursor: sqlite3_Cursor) -> int:
         if agg_table.startswith("br") and agg_table.endswith("brick_agg"):
             sqlstr = f"SELECT MAX(event_int) FROM {agg_table}"
             table_max_event_int = cursor.execute(sqlstr).fetchone()[0]
+            if not table_max_event_int:
+                table_max_event_int = 1
             if table_max_event_int > brick_aggs_max_event_int:
                 brick_aggs_max_event_int = table_max_event_int
     return brick_aggs_max_event_int

--- a/src/a20_world_logic/test/test_etl_pipeline/test_calc_belief_bud_person_mandate.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_calc_belief_bud_person_mandate.py
@@ -9,7 +9,6 @@ from src.a06_believer_logic.believer import believerunit_shop
 from src.a12_hub_toolbox.a12_path import (
     create_belief_believers_dir_path,
     create_belief_json_path,
-    create_belief_ote1_json_path,
     create_believerevent_path,
 )
 from src.a15_belief_logic.a15_path import (
@@ -19,6 +18,7 @@ from src.a15_belief_logic.belief import (
     beliefunit_shop,
     get_from_dict as beliefunit_get_from_dict,
 )
+from src.a18_etl_toolbox.a18_path import create_belief_ote1_json_path
 from src.a20_world_logic.test._util.a20_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir as worlds_dir,

--- a/src/a20_world_logic/test/test_etl_pipeline/test_calc_belief_bud_person_mandate.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_calc_belief_bud_person_mandate.py
@@ -11,6 +11,8 @@ from src.a12_hub_toolbox.a12_path import (
     create_belief_json_path,
     create_belief_ote1_json_path,
     create_believerevent_path,
+)
+from src.a15_belief_logic.a15_path import (
     create_bud_person_mandate_ledger_path as bud_mandate_path,
 )
 from src.a15_belief_logic.belief import (

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -17,14 +17,12 @@ from src.a11_bud_logic.test._util.a11_str import (
 )
 from src.a12_hub_toolbox.a12_path import (
     create_belief_json_path,
-    create_belief_ote1_csv_path,
     create_event_all_pack_path,
     create_event_expressed_pack_path as expressed_path,
     create_gut_path,
     create_job_path,
 )
 from src.a12_hub_toolbox.hub_tool import open_gut_file
-from src.a12_hub_toolbox.test._util.a12_str import belief_ote1_agg_str
 from src.a15_belief_logic.a15_path import (
     create_bud_person_mandate_ledger_path as bud_mandate,
 )
@@ -34,8 +32,10 @@ from src.a15_belief_logic.test._util.a15_str import (
 )
 from src.a16_pidgin_logic.test._util.a16_str import inx_name_str, otx_name_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
+from src.a18_etl_toolbox.a18_path import create_belief_ote1_csv_path
 from src.a18_etl_toolbox.test._util.a18_str import (
     belief_event_time_agg_str,
+    belief_ote1_agg_str,
     belief_person_nets_str,
     events_brick_agg_str,
     events_brick_valid_str,

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -18,7 +18,6 @@ from src.a11_bud_logic.test._util.a11_str import (
 from src.a12_hub_toolbox.a12_path import (
     create_belief_json_path,
     create_belief_ote1_csv_path,
-    create_bud_person_mandate_ledger_path as bud_mandate,
     create_event_all_pack_path,
     create_event_expressed_pack_path as expressed_path,
     create_gut_path,
@@ -26,6 +25,9 @@ from src.a12_hub_toolbox.a12_path import (
 )
 from src.a12_hub_toolbox.hub_tool import open_gut_file
 from src.a12_hub_toolbox.test._util.a12_str import belief_ote1_agg_str
+from src.a15_belief_logic.a15_path import (
+    create_bud_person_mandate_ledger_path as bud_mandate,
+)
 from src.a15_belief_logic.test._util.a15_str import (
     cumulative_minute_str,
     hour_label_str,

--- a/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_input_to_clarity.py
@@ -32,7 +32,10 @@ from src.a15_belief_logic.test._util.a15_str import (
 )
 from src.a16_pidgin_logic.test._util.a16_str import inx_name_str, otx_name_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
-from src.a18_etl_toolbox.a18_path import create_belief_ote1_csv_path
+from src.a18_etl_toolbox.a18_path import (
+    create_belief_ote1_csv_path,
+    create_last_run_metrics_path,
+)
 from src.a18_etl_toolbox.test._util.a18_str import (
     belief_event_time_agg_str,
     belief_ote1_agg_str,
@@ -108,6 +111,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario0_br000113Populat
     a23_sue_gut_path = create_gut_path(mstr_dir, a23_str, sue_inx)
     a23_sue_job_path = create_job_path(mstr_dir, a23_str, sue_inx)
     blrpern_job = create_prime_tablename("blrpern", "job", None)
+    last_run_metrics_path = create_last_run_metrics_path(mstr_dir)
 
     with sqlite3_connect(":memory:") as db_conn:
         cursor = db_conn.cursor()
@@ -144,6 +148,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario0_br000113Populat
         assert not db_table_exists(cursor, blrpern_job)
         assert not db_table_exists(cursor, belief_person_nets_str())
         assert not db_table_exists(cursor, belief_kpi001_person_nets_str())
+        assert not os_path_exists(last_run_metrics_path)
 
         # # create believerunits
         # self.believer_tables_to_event_believer_csvs(cursor)
@@ -207,6 +212,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario0_br000113Populat
         # assert get_row_count(cursor, belief_event_time_agg_str()) == 0
         # assert get_row_count(cursor, belief_ote1_agg_tablename) == 0
         assert get_row_count(cursor, belief_kpi001_person_nets_str()) == 0
+        assert os_path_exists(last_run_metrics_path)
 
 
 def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario1_PopulateBudPayRows(
@@ -556,7 +562,7 @@ def test_WorldUnit_sheets_input_to_clarity_with_cursor_Scenario5_CreatesFiles(
         assert os_path_exists(a23_sue_gut_path)
         assert os_path_exists(a23_sue_job_path)
         assert os_path_exists(sue37_mandate_path)
-        assert count_dirs_files(fay_world.worlds_dir) == 41
+        assert count_dirs_files(fay_world.worlds_dir) == 42
 
 
 def test_WorldUnit_sheets_input_to_clarity_mstr_Scenario0_CreatesDatabaseFile(

--- a/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
+++ b/src/a20_world_logic/test/test_etl_pipeline/test_stance_to_clarity.py
@@ -12,10 +12,10 @@ from src.a11_bud_logic.test._util.a11_str import (
     celldepth_str,
     quota_str,
 )
-from src.a12_hub_toolbox.test._util.a12_str import belief_ote1_agg_str
 from src.a16_pidgin_logic.test._util.a16_str import inx_name_str, otx_name_str
 from src.a17_idea_logic.idea_db_tool import upsert_sheet
 from src.a18_etl_toolbox.test._util.a18_str import (
+    belief_ote1_agg_str,
     events_brick_agg_str,
     events_brick_valid_str,
 )

--- a/src/a20_world_logic/world.py
+++ b/src/a20_world_logic/world.py
@@ -13,6 +13,7 @@ from src.a17_idea_logic.idea_db_tool import update_event_int_in_excel_files
 from src.a18_etl_toolbox.stance_tool import create_stance0001_file
 from src.a18_etl_toolbox.transformers import (
     add_belief_timeline_to_guts,
+    create_last_run_metrics_json,
     etl_belief_guts_to_belief_jobs,
     etl_belief_job_jsons_to_job_tables,
     etl_belief_json_person_nets_to_belief_person_nets_table,
@@ -157,6 +158,7 @@ class WorldUnit:
             cursor, self._belief_mstr_dir
         )
         populate_kpi_bundle(cursor)
+        create_last_run_metrics_json(cursor, self._belief_mstr_dir)
 
         # # create all belief_job and mandate reports
         # self.calc_belief_bud_person_mandate_net_ledgers()


### PR DESCRIPTION
## Summary by Sourcery

Migrate several path helper functions and constants from the hub toolbox into the ETL and belief-logic modules, introduce a new last-run metrics JSON in the ETL pipeline, improve maximum event logic, and update docs and tests accordingly.

New Features:
- Add create_last_run_metrics_path and create_last_run_metrics_json to record and save the last ETL run metrics.
- Integrate generation of last_run_metrics.json into the world logic ETL pipeline.

Enhancements:
- Move create_belief_ote1_csv_path/JSON into a18_etl_toolbox and relocate create_bud_person_mandate_ledger_path into a15_belief_logic.
- Default get_max_brick_agg_event_int to 1 when no rows are present.
- Clean up docstrings and function signatures in hubunit and stance_tool modules.

Documentation:
- Update str_funcs.md and test string utilities to reflect relocated and removed constants.

Tests:
- Remove obsolete tests for deleted path helpers; add tests for new path functions in a18 and a15 modules.
- Add tests for create_last_run_metrics_path and create_last_run_metrics_json behavior and file generation.
- Adjust existing ETL and max_event_int tests to cover the new default and scenario renumbering.