### PR TITLE
fix: set release bot identify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Install dependencies
         run: pip install python-semantic-release
 
+      - name: Set Git identity
+        run: |
+          git config user.name "Release Bot"
+          git config user.email "bot@example.com"
+
       - name: Show current directory and files
         run: |
           pwd
@@ -67,5 +72,5 @@ jobs:
 
       - name: Run python-semantic-release
         env:
-          GH_TOKEN: ${{ secrets.PAT_JAAR }}
+          GH_TOKEN: ${{ secrets.PAT_jaar }}
         run: semantic-release publish


### PR DESCRIPTION
## Summary by Sourcery

Configure the release workflow to set Git identity for the bot and correct the GH_TOKEN secret name

Bug Fixes:
- Fix the casing of the GH_TOKEN secret from PAT_JAAR to PAT_jaar in the release job

Enhancements:
- Add a step in the release workflow to set Git user.name and user.email for the Release Bot