### PR TITLE
feat: module linter checks all test functions ending with _Exists has…

### DIFF
--- a/src/a01_term_logic/test/test_term.py
+++ b/src/a01_term_logic/test/test_term.py
@@ -47,7 +47,7 @@ def test_default_knot_if_None_ReturnsObj():
     assert default_knot_if_None(bob_str) == bob_str
 
 
-def test_NameTerm_exists():
+def test_NameTerm_Exists():
     # ESTABLISH
     bob_str = "Bob"
     # WHEN
@@ -77,7 +77,7 @@ def test_NameTerm_is_name_ReturnsObj_Scenario1():
     assert x_nameterm.is_name(slash_str) is False
 
 
-def test_HealerName_exists():
+def test_HealerName_Exists():
     # ESTABLISH
     bob_str = "Bob"
     # WHEN
@@ -88,7 +88,7 @@ def test_HealerName_exists():
     assert inspect_getdoc(bob_healer_str) == doc_str
 
 
-def test_BelieverName_exists():
+def test_BelieverName_Exists():
     # ESTABLISH
     bob_str = "Bob"
     # WHEN
@@ -99,7 +99,7 @@ def test_BelieverName_exists():
     assert inspect_getdoc(bob_BelieverName_str) == doc_str
 
 
-def test_PartnerName_exists():
+def test_PartnerName_Exists():
     # ESTABLISH
     bob_str = "Bob"
     # WHEN
@@ -112,7 +112,7 @@ def test_PartnerName_exists():
     assert inspect_getdoc(bob_PartnerName) == doc_str
 
 
-def test_TitleTerm_exists():
+def test_TitleTerm_Exists():
     # ESTABLISH
     bob_str = "Bob"
     # WHEN
@@ -123,13 +123,13 @@ def test_TitleTerm_exists():
     assert inspect_getdoc(bob_nameterm) == doc_str
 
 
-def test_GroupTitle_exists():
+def test_GroupTitle_Exists():
     bikers_GroupTitle = GroupTitle(";bikers")
     assert bikers_GroupTitle is not None
     assert str(type(bikers_GroupTitle)).find("src.a01_term_logic.term.GroupTitle") > 0
 
 
-def test_LabelTerm_exists():
+def test_LabelTerm_Exists():
     # ESTABLISH
     empty_str = ""
     # WHEN
@@ -172,7 +172,7 @@ def test_CentralLabel_Exists():
     assert inspect_getdoc(x_central) == doc_str
 
 
-def test_RopeTerm_exists():
+def test_RopeTerm_Exists():
     # ESTABLISH
     empty_str = ""
     # WHEN
@@ -183,7 +183,7 @@ def test_RopeTerm_exists():
     assert inspect_getdoc(x_rope) == doc_str
 
 
-def test_EporTerm_exists():
+def test_EporTerm_Exists():
     # ESTABLISH
     empty_str = ""
     # WHEN

--- a/src/a02_finance_logic/test/test_allot/test_allot_scale_.py
+++ b/src/a02_finance_logic/test/test_allot/test_allot_scale_.py
@@ -9,7 +9,7 @@ from src.a02_finance_logic.allot import (
 )
 
 
-def test_GrainFloat_exists():
+def test_GrainFloat_Exists():
     # ESTABLISH
     x_float = 2.45
     # WHEN

--- a/src/a02_finance_logic/test/test_allot/test_finance_.py
+++ b/src/a02_finance_logic/test/test_allot/test_finance_.py
@@ -22,7 +22,7 @@ from src.a02_finance_logic.finance_config import (
 )
 
 
-def test_BitNum_exists():
+def test_BitNum_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN
@@ -53,7 +53,7 @@ def test_trim_bit_excess_ReturnsCorrectedFloat():
     assert trim_bit_excess(num=0.56, bit=0.133) == 0.532
 
 
-def test_RespectNum_exists():
+def test_RespectNum_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN
@@ -63,7 +63,7 @@ def test_RespectNum_exists():
     assert inspect_getdoc(y_RespectNum) == "RespectNum inherits from float class"
 
 
-def test_PennyNum_exists():
+def test_PennyNum_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN
@@ -90,7 +90,7 @@ def test_trim_penny_excess_ReturnsCorrectedFloat():
     assert trim_penny_excess(num=0.56, penny=0.133) == 0.532
 
 
-def test_MoneyUnit_exists():
+def test_MoneyUnit_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN
@@ -100,7 +100,7 @@ def test_MoneyUnit_exists():
     assert inspect_getdoc(y_moneyunit) == "MoneyUnit inherits from float class"
 
 
-def test_FundNum_exists():
+def test_FundNum_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN
@@ -129,7 +129,7 @@ def test_validate_fund_pool_ReturnsObj():
     assert validate_fund_pool(25) == 25
 
 
-def test_FundIota_exists():
+def test_FundIota_Exists():
     # ESTABLISH
     x_float = 0.045
     # WHEN

--- a/src/a03_group_logic/test/test__membership.py
+++ b/src/a03_group_logic/test/test__membership.py
@@ -30,7 +30,7 @@ from src.a03_group_logic.test._util.a03_str import (
 )
 
 
-def test_GroupCore_exists():
+def test_GroupCore_Exists():
     # ESTABLISH
     swim_str = ";swimmers"
     # WHEN
@@ -40,7 +40,7 @@ def test_GroupCore_exists():
     assert swim_groupcore.group_title == swim_str
 
 
-def test_MemberShip_exists():
+def test_MemberShip_Exists():
     # ESTABLISH
     swim_str = ",swim"
 
@@ -312,7 +312,7 @@ def test_MemberShip_clear_fund_give_take_SetsAttrCorrectly():
     assert bob_membership._fund_agenda_ratio_take == 0
 
 
-def test_AwardLink_exists():
+def test_AwardLink_Exists():
     # ESTABLISH
     bikers_str = "bikers"
 
@@ -343,7 +343,7 @@ def test_awardlink_shop_ReturnsObj():
     assert bikers_awardlink.take_force == bikers_take_force
 
 
-def test_AwardHeir_exists():
+def test_AwardHeir_Exists():
     # ESTABLISH / WHEN
     x_awardheir = AwardHeir()
 
@@ -423,7 +423,7 @@ def test_awardlinks_get_from_JSON_ReturnsObj_SimpleExample():
     assert awardlinks_obj_dict == teachers_obj_check_dict
 
 
-def test_AwardLine_exists():
+def test_AwardLine_Exists():
     # ESTABLISH
     bikers_str = "bikers"
     bikers_fund_give = 0.33
@@ -442,7 +442,7 @@ def test_AwardLine_exists():
     assert bikers_awardline._fund_take == bikers_fund_take
 
 
-def test_awardline_shop_ReturnsObj_exists():
+def test_awardline_shop_ReturnsObj_Exists():
     # ESTABLISH
     bikers_str = "bikers"
     bikers_str = bikers_str

--- a/src/a03_group_logic/test/test_group.py
+++ b/src/a03_group_logic/test/test_group.py
@@ -4,7 +4,7 @@ from src.a02_finance_logic.finance_config import default_fund_iota_if_None
 from src.a03_group_logic.group import GroupUnit, groupunit_shop, membership_shop
 
 
-def test_GroupUnit_exists():
+def test_GroupUnit_Exists():
     # ESTABLISH
     swim_str = ";swimmers"
     # WHEN
@@ -100,6 +100,7 @@ def test_GroupUnit_set_membership_CorrectlySetsAttr():
 
 
 def test_GroupUnit_set_membership_SetsAttr_credor_pool_debtor_pool():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     yao_str = "Yao"
     sue_str = "Sue"

--- a/src/a03_group_logic/test/test_partner_.py
+++ b/src/a03_group_logic/test/test_partner_.py
@@ -22,7 +22,7 @@ from src.a03_group_logic.test._util.a03_str import (
 )
 
 
-def test_PartnerUnit_exists():
+def test_PartnerUnit_Exists():
     # ESTABLISH
     bob_str = "Bob"
 

--- a/src/a03_group_logic/test/test_z_labor.py
+++ b/src/a03_group_logic/test/test_z_labor.py
@@ -96,7 +96,7 @@ def test_partyheir_shop_ReturnsObj():
     assert x_partyheir.solo == bob_solo_bool
 
 
-def test_LaborUnit_exists():
+def test_LaborUnit_Exists():
     # ESTABLISH / WHEN
     x_laborunit = LaborUnit()
 
@@ -219,7 +219,7 @@ def test_LaborUnit_del_partyunit_CorrectlyDeletes_partys_v1():
     assert len(x_laborunit._partys) == 1
 
 
-def test_LaborHeir_exists():
+def test_LaborHeir_Exists():
     # ESTABLISH / WHEN
     x_laborheir = LaborHeir()
 

--- a/src/a05_plan_logic/test/test_/test_healer.py
+++ b/src/a05_plan_logic/test/test_/test_healer.py
@@ -5,7 +5,7 @@ from src.a05_plan_logic.healer import (
 )
 
 
-def test_HealerLink_exists():
+def test_HealerLink_Exists():
     # ESTABLISH
     run_str = ";runners"
     run_healer_names = {run_str}
@@ -103,6 +103,7 @@ def test_HealerLink_healer_name_exists_ReturnsObj():
 
 
 def test_HealerLink_any_healer_name_exists_ReturnsObj():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     x_healerlink = healerlink_shop()
     assert x_healerlink.any_healer_name_exists() is False

--- a/src/a05_plan_logic/test/test_/test_range_toolbox.py
+++ b/src/a05_plan_logic/test/test_/test_range_toolbox.py
@@ -5,7 +5,7 @@ from src.a05_plan_logic.range_toolbox import (
 )
 
 
-def test_RangeUnit_exists():
+def test_RangeUnit_Exists():
     # ESTABLISH
     x_gogo = 0
     x_stop = 20

--- a/src/a06_believer_logic/test/test_believer_settle/test_z_tree_metrics.py
+++ b/src/a06_believer_logic/test/test_believer_settle/test_z_tree_metrics.py
@@ -6,7 +6,7 @@ from src.a06_believer_logic.believer_main import believerunit_shop
 from src.a06_believer_logic.test._util.example_believers import believerunit_v001
 
 
-def test_BelieverUnit_get_tree_metrics_exists():
+def test_BelieverUnit_get_tree_metrics_Exists():
     # ESTABLISH
     zia_believer = believerunit_shop(believer_name="Zia")
 

--- a/src/a07_timeline_logic/test/test_/test_config_.py
+++ b/src/a07_timeline_logic/test/test_/test_config_.py
@@ -44,7 +44,7 @@ from src.a07_timeline_logic.timeline_main import (
 )
 
 
-def test_TimeLineLabel_exists():
+def test_TimeLineLabel_Exists():
     # ESTABLISH
     empty_str = ""
     # WHEN

--- a/src/a08_believer_atom_logic/test/test_atom/test_atom_core.py
+++ b/src/a08_believer_atom_logic/test/test_atom/test_atom_core.py
@@ -12,7 +12,7 @@ from src.a08_believer_atom_logic.atom_main import BelieverAtom, believeratom_sho
 from src.a08_believer_atom_logic.test._util.a08_str import DELETE_str, INSERT_str
 
 
-def test_BelieverAtom_exists():
+def test_BelieverAtom_Exists():
     # ESTABLISH / WHEN
     x_believeratom = BelieverAtom()
 

--- a/src/a08_believer_atom_logic/test/test_atom/test_atom_row.py
+++ b/src/a08_believer_atom_logic/test/test_atom/test_atom_row.py
@@ -15,7 +15,7 @@ from src.a08_believer_atom_logic.atom_main import (
 from src.a08_believer_atom_logic.test._util.a08_str import DELETE_str, INSERT_str
 
 
-def test_AtomRow_exists():
+def test_AtomRow_Exists():
     # ESTABLISH /  WHEN
     x_atomrow = AtomRow()
 

--- a/src/a08_believer_atom_logic/test/test_atom/test_atom_sift_delete.py
+++ b/src/a08_believer_atom_logic/test/test_atom/test_atom_sift_delete.py
@@ -49,6 +49,7 @@ def test_sift_atom_ReturnsObj_BelieverAtom_DELETE_believer_partnerunit():
 
 
 def test_sift_atom_ReturnsObj_BelieverAtom_DELETE_believer_partner_membership():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     bob_str = "Bob"
     yao_str = "Yao"
@@ -155,6 +156,7 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_planunit():
 
 
 def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_awardlink():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"
@@ -189,6 +191,7 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_awardlink():
 
 
 def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_reasonunit():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"
@@ -223,7 +226,8 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_reasonunit():
     assert sift_believeratom(sue_believer, clean_week_atom)
 
 
-def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_reason_caseunit_exists():
+def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_reason_caseunit_Exists():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"
@@ -272,6 +276,7 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_reason_caseunit_e
 
 
 def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_partyunit():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"
@@ -306,6 +311,7 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_partyunit():
 
 
 def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_healerlink():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"
@@ -340,6 +346,7 @@ def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_healerlink():
 
 
 def test_sift_atom_SetsBelieverDeltaBelieverAtom_believer_plan_factunit():
+    # sourcery skip: extract-duplicate-method
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"

--- a/src/a08_believer_atom_logic/test/test_atom/test_atom_sift_insert.py
+++ b/src/a08_believer_atom_logic/test/test_atom/test_atom_sift_insert.py
@@ -184,7 +184,7 @@ def test_sift_atom_ReturnsObj_BelieverAtom_INSERT_believer_plan_reasonunit():
     assert not sift_believeratom(sue_believer, clean_week_atom)
 
 
-def test_sift_atom_ReturnsObj_BelieverAtom_INSERT_believer_plan_reason_caseunit_exists():
+def test_sift_atom_ReturnsObj_BelieverAtom_INSERT_believer_plan_reason_caseunit_Exists():
     # ESTABLISH
     sue_believer = believerunit_shop("Sue")
     casa_str = "casa"

--- a/src/a09_pack_logic/test/test_delta/test_delta_.py
+++ b/src/a09_pack_logic/test/test_delta/test_delta_.py
@@ -35,7 +35,7 @@ from src.a09_pack_logic.test._util.example_deltas import (
 )
 
 
-def test_BelieverDelta_exists():
+def test_BelieverDelta_Exists():
     # ESTABLISH / WHEN
     x_believerdelta = BelieverDelta()
 

--- a/src/a09_pack_logic/test/test_pack/test_pack_.py
+++ b/src/a09_pack_logic/test/test_pack/test_pack_.py
@@ -45,7 +45,7 @@ def test_get_init_pack_id_if_None_ReturnsObj():
     assert get_init_pack_id_if_None(1) == 1
 
 
-def test_PackUnit_exists():
+def test_PackUnit_Exists():
     # ESTABLISH / WHEN
     x_packunit = PackUnit()
 

--- a/src/a99_module_linter/test/test_module_dirs.py
+++ b/src/a99_module_linter/test/test_module_dirs.py
@@ -394,6 +394,7 @@ def test_Modules_path_FunctionStructureAndFormat():
     # ESTABLISH / WHEN
     x_count = 0
     path_functions = {}
+    all_test_functions = set()
     modules_path_funcs = {}
     filtered_modules_path_funcs = {}
     filterout_path_funcs = {
@@ -407,9 +408,9 @@ def test_Modules_path_FunctionStructureAndFormat():
         path_func_set = set()
         modules_path_funcs[module_desc] = path_func_set
         filtered_modules_path_funcs[module_desc] = filtered_path_funcs
-        for filenames in filenames_set:
-            file_dir = create_path(module_dir, filenames[0])
-            file_path = create_path(file_dir, filenames[1])
+        for filepath_set in filenames_set:
+            file_dir = create_path(module_dir, filepath_set[0])
+            file_path = create_path(file_dir, filepath_set[1])
             file_functions = get_top_level_functions(file_path)
             for function_name in file_functions:
                 x_count += 1
@@ -424,16 +425,18 @@ def test_Modules_path_FunctionStructureAndFormat():
                         and function_name not in filterout_path_funcs
                     ):
                         filtered_path_funcs.add(function_name)
+                if str(function_name).startswith("test_"):
+                    all_test_functions.add(function_name)
 
     print(f"Total path functions found: {len(path_functions)}")
     for function_name, file_path in path_functions.items():
         func_docstring = get_docstring(file_path, function_name)
-        if not func_docstring:
-            print(f"docstring for {function_name} is None")
-        else:
-            print(
-                f"docstring for {function_name}: \t{func_docstring.replace("\n", "")}"
-            )
+        # if not func_docstring:
+        #     print(f"docstring for {function_name} is None")
+        # else:
+        #     print(
+        #         f"docstring for {function_name}: \t{func_docstring.replace("\n", "")}"
+        #     )
         assert func_docstring is not None, function_name
 
     # print(f"Path functions: {path_functions.keys()=}")
@@ -461,6 +464,8 @@ def test_Modules_path_FunctionStructureAndFormat():
                 path_funcs, module_desc, test_path_func_names
             )
 
+    check_all_test_functions_have_proper_naming_format(all_test_functions)
+
 
 def check_if_test_ReturnsObj_pytests_exist(
     path_funcs: set, module_desc: str, test_path_func_names: set[str]
@@ -484,7 +489,7 @@ def check_if_test_HasDocString_pytests_exist(
 ):
     for path_func in path_funcs:
         pytest_for_func_exists = False
-        print(f"{module_desc} {path_func}")
+        # print(f"{module_desc} {path_func}")
         expected_test_func = f"test_{path_func}_HasDocString"
         for test_path_func_name in test_path_func_names:
             if test_path_func_name.startswith(expected_test_func):
@@ -494,6 +499,14 @@ def check_if_test_HasDocString_pytests_exist(
             # )
         assert pytest_for_func_exists, f"missing {expected_test_func=}"
         # print(f"{module_desc} {test_func_exists} {path_func}")
+
+
+def check_all_test_functions_have_proper_naming_format(all_test_functions):
+    for test_function_name in sorted(all_test_functions):
+        test_function_name = str(test_function_name)
+        assert not test_function_name.endswith(
+            "_exists"
+        ), f"{test_function_name} name format"
 
 
 def test_check_Modules_filenames_FollowFileNameConventions_NoNamingCollision():


### PR DESCRIPTION
… correct letter casing closes #928

## Summary by Sourcery

Enforce consistent letter casing for test functions ending with '_Exists' by extending the module linter to collect test names, assert the proper naming format, and update existing tests to conform.

New Features:
- Add module linter check to enforce correct uppercase suffix '_Exists' on all test functions

Enhancements:
- Collect and aggregate all test function names in test_Module_dirs and integrate a helper to assert naming conventions

Tests:
- Rename numerous test functions across modules from suffix '_exists' to '_Exists' to comply with the new naming rule