### PR TITLE
874 create gui for calendarto do creation

### DIFF
--- a/src/a03_group_logic/test/_util/a03_str.py
+++ b/src/a03_group_logic/test/_util/a03_str.py
@@ -1,4 +1,5 @@
 from src.a01_term_logic.test._util.a01_str import knot_str
+from src.a02_finance_logic.test._util.a02_str import fund_iota_str
 
 
 def _credor_pool_str() -> str:

--- a/src/a03_group_logic/test/test__membership.py
+++ b/src/a03_group_logic/test/test__membership.py
@@ -63,6 +63,10 @@ def test_MemberShip_Exists():
     obj_attrs = set(swim_membership.__dict__.keys())
     print(sorted(list(obj_attrs)))
     assert obj_attrs == {
+        partner_name_str(),
+        group_title_str(),
+        group_cred_points_str(),
+        group_debt_points_str(),
         _credor_pool_str(),
         _debtor_pool_str(),
         _fund_agenda_give_str(),
@@ -71,10 +75,6 @@ def test_MemberShip_Exists():
         _fund_agenda_take_str(),
         _fund_give_str(),
         _fund_take_str(),
-        partner_name_str(),
-        group_cred_points_str(),
-        group_debt_points_str(),
-        group_title_str(),
     }
 
 

--- a/src/a03_group_logic/test/test_group.py
+++ b/src/a03_group_logic/test/test_group.py
@@ -2,25 +2,48 @@ from pytest import raises as pytest_raises
 from src.a01_term_logic.rope import default_knot_if_None
 from src.a02_finance_logic.finance_config import default_fund_iota_if_None
 from src.a03_group_logic.group import GroupUnit, groupunit_shop, membership_shop
+from src.a03_group_logic.test._util.a03_str import (
+    _credor_pool_str,
+    _debtor_pool_str,
+    _fund_agenda_give_str,
+    _fund_agenda_take_str,
+    _fund_give_str,
+    _fund_take_str,
+    _memberships_str,
+    fund_iota_str,
+    group_title_str,
+    knot_str,
+)
 
 
 def test_GroupUnit_Exists():
-    # ESTABLISH
-    swim_str = ";swimmers"
-    # WHEN
-    swim_groupunit = GroupUnit(group_title=swim_str)
+    # ESTABLISH / WHEN
+    x_groupunit = GroupUnit()
     # THEN
-    assert swim_groupunit is not None
-    assert swim_groupunit.group_title == swim_str
-    assert swim_groupunit._memberships is None
-    assert swim_groupunit._fund_give is None
-    assert swim_groupunit._fund_take is None
-    assert swim_groupunit._fund_agenda_give is None
-    assert swim_groupunit._fund_agenda_take is None
-    assert swim_groupunit._credor_pool is None
-    assert swim_groupunit._debtor_pool is None
-    assert swim_groupunit.knot is None
-    assert swim_groupunit.fund_iota is None
+    assert x_groupunit is not None
+    assert not x_groupunit.group_title
+    assert not x_groupunit._memberships
+    assert not x_groupunit._fund_give
+    assert not x_groupunit._fund_take
+    assert not x_groupunit._fund_agenda_give
+    assert not x_groupunit._fund_agenda_take
+    assert not x_groupunit._credor_pool
+    assert not x_groupunit._debtor_pool
+    assert not x_groupunit.knot
+    assert not x_groupunit.fund_iota
+    print(f"{x_groupunit.__dict__=}")
+    assert set(x_groupunit.__dict__.keys()) == {
+        group_title_str(),
+        _memberships_str(),
+        _fund_give_str(),
+        _fund_take_str(),
+        _fund_agenda_give_str(),
+        _fund_agenda_take_str(),
+        _credor_pool_str(),
+        _debtor_pool_str(),
+        knot_str(),
+        fund_iota_str(),
+    }
 
 
 def test_groupunit_shop_ReturnsObj():

--- a/src/a22_belief_viewer/belief_viewer_app.py
+++ b/src/a22_belief_viewer/belief_viewer_app.py
@@ -27,9 +27,23 @@ def get_belief_viewer_template() -> str:
         
         <div class="partners_controls">
             <input type="checkbox" id="show_partners"><label for="show_partners">partners</label>
+        <input type="checkbox" id="show_partner_cred_points"><label for="show_partner_cred_points">partner_cred_points</label>,
+        <input type="checkbox" id="show_partner_debt_points"><label for="show_partner_debt_points">partner_debt_points</label>,
+        <input type="checkbox" id="show_partner_memberships"><label for="show_partner_memberships">partner_memberships</label>,
+        <input type="checkbox" id="show_partner_credor_pool"><label for="show_partner_credor_pool">partner_credor_pool</label>,
+        <input type="checkbox" id="show_partner_debtor_pool"><label for="show_partner_debtor_pool">partner_debtor_pool</label>,
+        <input type="checkbox" id="show_partner_irrational_partner_debt_points"><label for="show_partner_irrational_partner_debt_points">partner_irrational_partner_debt_points</label>,
+        <input type="checkbox" id="show_partner_inallocable_partner_debt_points"><label for="show_partner_inallocable_partner_debt_points">partner_inallocable_partner_debt_points</label>,
+        <input type="checkbox" id="show_partner_fund_give"><label for="show_partner_fund_give">partner_fund_give</label>,
+        <input type="checkbox" id="show_partner_fund_take"><label for="show_partner_fund_take">partner_fund_take</label>,
+        <input type="checkbox" id="show_partner_fund_agenda_give"><label for="show_partner_fund_agenda_give">partner_fund_agenda_give</label>,
+        <input type="checkbox" id="show_partner_fund_agenda_take"><label for="show_partner_fund_agenda_take">partner_fund_agenda_take</label>,
+        <input type="checkbox" id="show_partner_fund_agenda_ratio_give"><label for="show_partner_fund_agenda_ratio_give">partner_fund_agenda_ratio_give</label>,
+        <input type="checkbox" id="show_partner_fund_agenda_ratio_take"><label for="show_partner_fund_agenda_ratio_take">partner_fund_agenda_ratio_take</label>,
         </div>
-        <div id="partnersTreeContainer" class="plan_tree_display"></div>
+        <div id="partnersContainer" class="plan_tree_display"></div>
         <div class="plan_controls">
+            <input type="checkbox" id="show_planroot"><label for="show_planroot">planroot</label>
             <input type="checkbox" id="show_level"><label for="show_level">level</label>
             <input type="checkbox" id="show_moment_label"><label for="show_moment_label">moment_label</label>
             <input type="checkbox" id="show_task"><label for="show_task">task</label>

--- a/src/a22_belief_viewer/belief_viewer_app.py
+++ b/src/a22_belief_viewer/belief_viewer_app.py
@@ -27,19 +27,32 @@ def get_belief_viewer_template() -> str:
         
         <div class="partners_controls">
             <input type="checkbox" id="show_partners"><label for="show_partners">partners</label>
-        <input type="checkbox" id="show_partner_cred_points"><label for="show_partner_cred_points">partner_cred_points</label>,
-        <input type="checkbox" id="show_partner_debt_points"><label for="show_partner_debt_points">partner_debt_points</label>,
-        <input type="checkbox" id="show_partner_memberships"><label for="show_partner_memberships">partner_memberships</label>,
-        <input type="checkbox" id="show_partner_credor_pool"><label for="show_partner_credor_pool">partner_credor_pool</label>,
-        <input type="checkbox" id="show_partner_debtor_pool"><label for="show_partner_debtor_pool">partner_debtor_pool</label>,
-        <input type="checkbox" id="show_partner_irrational_partner_debt_points"><label for="show_partner_irrational_partner_debt_points">partner_irrational_partner_debt_points</label>,
-        <input type="checkbox" id="show_partner_inallocable_partner_debt_points"><label for="show_partner_inallocable_partner_debt_points">partner_inallocable_partner_debt_points</label>,
-        <input type="checkbox" id="show_partner_fund_give"><label for="show_partner_fund_give">partner_fund_give</label>,
-        <input type="checkbox" id="show_partner_fund_take"><label for="show_partner_fund_take">partner_fund_take</label>,
-        <input type="checkbox" id="show_partner_fund_agenda_give"><label for="show_partner_fund_agenda_give">partner_fund_agenda_give</label>,
-        <input type="checkbox" id="show_partner_fund_agenda_take"><label for="show_partner_fund_agenda_take">partner_fund_agenda_take</label>,
-        <input type="checkbox" id="show_partner_fund_agenda_ratio_give"><label for="show_partner_fund_agenda_ratio_give">partner_fund_agenda_ratio_give</label>,
-        <input type="checkbox" id="show_partner_fund_agenda_ratio_take"><label for="show_partner_fund_agenda_ratio_take">partner_fund_agenda_ratio_take</label>,
+            <input type="checkbox" id="show_partner_cred_points"><label for="show_partner_cred_points">cred_points</label>
+            <input type="checkbox" id="show_partner_debt_points"><label for="show_partner_debt_points">debt_points</label>
+            <input type="checkbox" id="show_partner_memberships"><label for="show_partner_memberships">memberships</label>
+            <input type="checkbox" id="show_partner_credor_pool"><label for="show_partner_credor_pool">credor_pool</label>
+            <input type="checkbox" id="show_partner_debtor_pool"><label for="show_partner_debtor_pool">debtor_pool</label>
+            <input type="checkbox" id="show_partner_irrational_partner_debt_points"><label for="show_partner_irrational_partner_debt_points">irrational_partner_debt_points</label>
+            <input type="checkbox" id="show_partner_inallocable_partner_debt_points"><label for="show_partner_inallocable_partner_debt_points">inallocable_partner_debt_points</label>
+            <input type="checkbox" id="show_partner_fund_give"><label for="show_partner_fund_give">fund_give</label>
+            <input type="checkbox" id="show_partner_fund_take"><label for="show_partner_fund_take">fund_take</label>
+            <input type="checkbox" id="show_partner_fund_agenda_give"><label for="show_partner_fund_agenda_give">fund_agenda_give</label>
+            <input type="checkbox" id="show_partner_fund_agenda_take"><label for="show_partner_fund_agenda_take">fund_agenda_take</label>
+            <input type="checkbox" id="show_partner_fund_agenda_ratio_give"><label for="show_partner_fund_agenda_ratio_give">fund_agenda_ratio_give</label>
+            <input type="checkbox" id="show_partner_fund_agenda_ratio_take"><label for="show_partner_fund_agenda_ratio_take">fund_agenda_ratio_take</label>
+            <br>
+            <input type="checkbox" id="show_partner_membership_group_title"><label for="show_partner_membership_group_title">membership_group_title</label>
+            <input type="checkbox" id="show_partner_membership_group_cred_points"><label for="show_partner_membership_group_cred_points">membership_group_cred_points</label>
+            <input type="checkbox" id="show_partner_membership_group_debt_points"><label for="show_partner_membership_group_debt_points">membership_group_debt_points</label>
+            <input type="checkbox" id="show_partner_membership__credor_pool"><label for="show_partner_membership__credor_pool">membership__credor_pool</label>
+            <input type="checkbox" id="show_partner_membership__debtor_pool"><label for="show_partner_membership__debtor_pool">membership__debtor_pool</label>
+            <input type="checkbox" id="show_partner_membership__fund_agenda_give"><label for="show_partner_membership__fund_agenda_give">membership__fund_agenda_give</label>
+            <input type="checkbox" id="show_partner_membership__fund_agenda_ratio_give"><label for="show_partner_membership__fund_agenda_ratio_give">membership__fund_agenda_ratio_give</label>
+            <input type="checkbox" id="show_partner_membership__fund_agenda_ratio_take"><label for="show_partner_membership__fund_agenda_ratio_take">membership__fund_agenda_ratio_take</label>
+            <input type="checkbox" id="show_partner_membership__fund_agenda_take"><label for="show_partner_membership__fund_agenda_take">membership__fund_agenda_take</label>
+            <input type="checkbox" id="show_partner_membership__fund_give"><label for="show_partner_membership__fund_give">membership__fund_give</label>
+            <input type="checkbox" id="show_partner_membership__fund_take"><label for="show_partner_membership__fund_take">membership__fund_take</label>
+            
         </div>
         <div id="partnersContainer" class="plan_tree_display"></div>
         <div class="plan_controls">

--- a/src/a22_belief_viewer/belief_viewer_tool.py
+++ b/src/a22_belief_viewer/belief_viewer_tool.py
@@ -152,6 +152,7 @@ def get_plan_view_dict(x_plan: PlanUnit) -> dict[str,]:
 def get_partners_view_dict(belief: BeliefUnit) -> dict[str,]:
     partners_dict = {}
     for partner in belief.partners.values():
+
         partner_cred_points_readable = (
             f"partner_cred_points: {partner.partner_cred_points}"
         )
@@ -173,12 +174,39 @@ def get_partners_view_dict(belief: BeliefUnit) -> dict[str,]:
         _fund_agenda_ratio_take_readable = (
             f"_fund_agenda_ratio_take: {partner._fund_agenda_ratio_take}"
         )
-
+        x_members_dict = {
+            x_membership.group_title: {
+                "partner_name": x_membership.partner_name,
+                "group_title": x_membership.group_title,
+                "group_cred_points": x_membership.group_cred_points,
+                "group_debt_points": x_membership.group_debt_points,
+                "_credor_pool": x_membership._credor_pool,
+                "_debtor_pool": x_membership._debtor_pool,
+                "_fund_agenda_give": x_membership._fund_agenda_give,
+                "_fund_agenda_ratio_give": x_membership._fund_agenda_ratio_give,
+                "_fund_agenda_ratio_take": x_membership._fund_agenda_ratio_take,
+                "_fund_agenda_take": x_membership._fund_agenda_take,
+                "_fund_give": x_membership._fund_give,
+                "_fund_take": x_membership._fund_take,
+                "group_title_readable": f"group_title: {x_membership.group_title}",
+                "group_cred_points_readable": f"group_cred_points: {x_membership.group_cred_points}",
+                "group_debt_points_readable": f"group_debt_points: {x_membership.group_debt_points}",
+                "_credor_pool_readable": f"_credor_pool: {x_membership._credor_pool}",
+                "_debtor_pool_readable": f"_debtor_pool: {x_membership._debtor_pool}",
+                "_fund_agenda_give_readable": f"_fund_agenda_give: {x_membership._fund_agenda_give}",
+                "_fund_agenda_ratio_give_readable": f"_fund_agenda_ratio_give: {x_membership._fund_agenda_ratio_give}",
+                "_fund_agenda_ratio_take_readable": f"_fund_agenda_ratio_take: {x_membership._fund_agenda_ratio_take}",
+                "_fund_agenda_take_readable": f"_fund_agenda_take: {x_membership._fund_agenda_take}",
+                "_fund_give_readable": f"_fund_give: {x_membership._fund_give}",
+                "_fund_take_readable": f"_fund_take: {x_membership._fund_take}",
+            }
+            for x_membership in partner._memberships.values()
+        }
         partner_dict = {
             "partner_name": partner.partner_name,
             "partner_cred_points": partner.partner_cred_points,
             "partner_debt_points": partner.partner_debt_points,
-            "_memberships": partner._memberships,
+            "_memberships": x_members_dict,
             "_credor_pool": partner._credor_pool,
             "_debtor_pool": partner._debtor_pool,
             "_irrational_partner_debt_points": partner._irrational_partner_debt_points,

--- a/src/a22_belief_viewer/belief_viewer_tool.py
+++ b/src/a22_belief_viewer/belief_viewer_tool.py
@@ -175,6 +175,7 @@ def get_partners_view_dict(belief: BeliefUnit) -> dict[str,]:
         )
 
         partner_dict = {
+            "partner_name": partner.partner_name,
             "partner_cred_points": partner.partner_cred_points,
             "partner_debt_points": partner.partner_debt_points,
             "_memberships": partner._memberships,

--- a/src/a22_belief_viewer/static/app.js
+++ b/src/a22_belief_viewer/static/app.js
@@ -1,6 +1,7 @@
 // Global state
 let planTreeData = null;
 let show_partners = true;
+let show_planroot = true;
 let show_awardunits = false;
 let show_awardheirs = false;
 let show_awardlines = false;
@@ -42,6 +43,7 @@ let show_uid = false;
 // Initialize the app when DOM loads
 document.addEventListener('DOMContentLoaded', function () {
     const show_partnersCheckbox = document.getElementById('show_partners');
+    const show_planrootCheckbox = document.getElementById('show_planroot');
     const show_awardunitsCheckbox = document.getElementById('show_awardunits');
     const show_awardheirsCheckbox = document.getElementById('show_awardheirs');
     const show_awardlinesCheckbox = document.getElementById('show_awardlines');
@@ -81,7 +83,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const show_uidCheckbox = document.getElementById('show_uid');
 
     // Set up checkbox event listener
-    show_partnersCheckbox.addEventListener('change', function () { show_partners = this.checked; renderPlanTree(); });
+    show_partnersCheckbox.addEventListener('change', function () { show_partners = this.checked; renderPartnersData(); });
+    show_planrootCheckbox.addEventListener('change', function () { show_planroot = this.checked; renderPlanTree(); });
     show_awardunitsCheckbox.addEventListener('change', function () { show_awardunits = this.checked; renderPlanTree(); });
     show_awardheirsCheckbox.addEventListener('change', function () { show_awardheirs = this.checked; renderPlanTree(); });
     show_awardlinesCheckbox.addEventListener('change', function () { show_awardlines = this.checked; renderPlanTree(); });
@@ -121,20 +124,43 @@ document.addEventListener('DOMContentLoaded', function () {
     show_uidCheckbox.addEventListener('change', function () { show_uid = this.checked; renderPlanTree(); });
 
     // Load initial tree data
-    loadPlanTreeData();
+    loadBeliefData();
 });
 
 // Fetch tree data from server
-async function loadPlanTreeData() {
+async function loadBeliefData() {
     try {
         const response = await fetch('/api/beliefunit_view');
         beliefViewData = await response.json();
         planTreeData = beliefViewData.planroot;
+        partnersData = beliefViewData.partners;
         renderPlanTree();
+        renderPartnersData();
     } catch (error) {
         console.error('Error loading tree data:', error);
         document.getElementById('planTreeContainer').innerHTML = '<p>Error loading tree data</p>';
+        document.getElementById('planTreeContainer').innerHTML = '<p>Error loading tree data</p>';
     }
+}
+
+
+// Render PartnersData and its membership attributes
+function renderPartnersData() {
+    const partners_container = document.getElementById('partnersContainer');
+    partners_container.innerHTML = buildPartnersHtml(partnersData);
+}
+
+function buildPartnersHtml(partnersData) {
+    if (!partnersData || !show_partners) {
+        return "";
+    }
+    const partners_indent = '&nbsp;'.repeat(2);
+    let html = '';
+    Object.values(partnersData).forEach(partner => {
+        html += `${partners_indent}${partner.partner_name}<br>`;
+        // html += `<br>${partners_indent}${partner.partner_name}`;
+    });
+    return html
 }
 
 // Render the tree structure
@@ -149,6 +175,9 @@ function renderPlanTree() {
 
 // Recursively render a PlanUnit and its children
 function renderPlanUnit(planUnit, level) {
+    if (!show_planroot) {
+        return "";
+    }
     const indent = '&nbsp;'.repeat(level * 2);
     const levelIndicator = show_level ? ` level${planUnit._level}` : '';
     const taskIndicator = planUnit.task && show_task ? ' TASK' : '';

--- a/src/a22_belief_viewer/static/app.js
+++ b/src/a22_belief_viewer/static/app.js
@@ -1,6 +1,19 @@
 // Global state
 let planTreeData = null;
 let show_partners = true;
+let show_partner_cred_points = false;
+let show_partner_debt_points = false;
+let show_partner_memberships = false;
+let show_partner_credor_pool = false;
+let show_partner_debtor_pool = false;
+let show_partner_irrational_partner_debt_points = false;
+let show_partner_inallocable_partner_debt_points = false;
+let show_partner_fund_give = false;
+let show_partner_fund_take = false;
+let show_partner_fund_agenda_give = false;
+let show_partner_fund_agenda_take = false;
+let show_partner_fund_agenda_ratio_give = false;
+let show_partner_fund_agenda_ratio_take = false;
 let show_planroot = true;
 let show_awardunits = false;
 let show_awardheirs = false;
@@ -43,6 +56,19 @@ let show_uid = false;
 // Initialize the app when DOM loads
 document.addEventListener('DOMContentLoaded', function () {
     const show_partnersCheckbox = document.getElementById('show_partners');
+    const show_partner_cred_pointsCheckbox = document.getElementById('show_partner_cred_points')
+    const show_partner_debt_pointsCheckbox = document.getElementById('show_partner_debt_points')
+    const show_partner_membershipsCheckbox = document.getElementById('show_partner_memberships')
+    const show_partner_credor_poolCheckbox = document.getElementById('show_partner_credor_pool')
+    const show_partner_debtor_poolCheckbox = document.getElementById('show_partner_debtor_pool')
+    const show_partner_irrational_partner_debt_pointsCheckbox = document.getElementById('show_partner_irrational_partner_debt_points')
+    const show_partner_inallocable_partner_debt_pointsCheckbox = document.getElementById('show_partner_inallocable_partner_debt_points')
+    const show_partner_fund_giveCheckbox = document.getElementById('show_partner_fund_give')
+    const show_partner_fund_takeCheckbox = document.getElementById('show_partner_fund_take')
+    const show_partner_fund_agenda_giveCheckbox = document.getElementById('show_partner_fund_agenda_give')
+    const show_partner_fund_agenda_takeCheckbox = document.getElementById('show_partner_fund_agenda_take')
+    const show_partner_fund_agenda_ratio_giveCheckbox = document.getElementById('show_partner_fund_agenda_ratio_give')
+    const show_partner_fund_agenda_ratio_takeCheckbox = document.getElementById('show_partner_fund_agenda_ratio_take')
     const show_planrootCheckbox = document.getElementById('show_planroot');
     const show_awardunitsCheckbox = document.getElementById('show_awardunits');
     const show_awardheirsCheckbox = document.getElementById('show_awardheirs');
@@ -84,6 +110,19 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Set up checkbox event listener
     show_partnersCheckbox.addEventListener('change', function () { show_partners = this.checked; renderPartnersData(); });
+    show_partner_cred_pointsCheckbox.addEventListener('change', function () { show_partner_cred_points = this.checked; renderPartnersData(); });
+    show_partner_debt_pointsCheckbox.addEventListener('change', function () { show_partner_debt_points = this.checked; renderPartnersData(); });
+    show_partner_membershipsCheckbox.addEventListener('change', function () { show_partner_memberships = this.checked; renderPartnersData(); });
+    show_partner_credor_poolCheckbox.addEventListener('change', function () { show_partner_credor_pool = this.checked; renderPartnersData(); });
+    show_partner_debtor_poolCheckbox.addEventListener('change', function () { show_partner_debtor_pool = this.checked; renderPartnersData(); });
+    show_partner_irrational_partner_debt_pointsCheckbox.addEventListener('change', function () { show_partner_irrational_partner_debt_points = this.checked; renderPartnersData(); });
+    show_partner_inallocable_partner_debt_pointsCheckbox.addEventListener('change', function () { show_partner_inallocable_partner_debt_points = this.checked; renderPartnersData(); });
+    show_partner_fund_giveCheckbox.addEventListener('change', function () { show_partner_fund_give = this.checked; renderPartnersData(); });
+    show_partner_fund_takeCheckbox.addEventListener('change', function () { show_partner_fund_take = this.checked; renderPartnersData(); });
+    show_partner_fund_agenda_giveCheckbox.addEventListener('change', function () { show_partner_fund_agenda_give = this.checked; renderPartnersData(); });
+    show_partner_fund_agenda_takeCheckbox.addEventListener('change', function () { show_partner_fund_agenda_take = this.checked; renderPartnersData(); });
+    show_partner_fund_agenda_ratio_giveCheckbox.addEventListener('change', function () { show_partner_fund_agenda_ratio_give = this.checked; renderPartnersData(); });
+    show_partner_fund_agenda_ratio_takeCheckbox.addEventListener('change', function () { show_partner_fund_agenda_ratio_take = this.checked; renderPartnersData(); });
     show_planrootCheckbox.addEventListener('change', function () { show_planroot = this.checked; renderPlanTree(); });
     show_awardunitsCheckbox.addEventListener('change', function () { show_awardunits = this.checked; renderPlanTree(); });
     show_awardheirsCheckbox.addEventListener('change', function () { show_awardheirs = this.checked; renderPlanTree(); });
@@ -155,9 +194,24 @@ function buildPartnersHtml(partnersData) {
         return "";
     }
     const partners_indent = '&nbsp;'.repeat(2);
+
     let html = '';
     Object.values(partnersData).forEach(partner => {
-        html += `${partners_indent}${partner.partner_name}<br>`;
+        html += `<br>${partners_indent}${partner.partner_name}`;
+        if (show_partner_cred_points) { html += `<br>${partners_indent}    ${partner.partner_cred_points_readable}` };
+        if (show_partner_debt_points) { html += `<br>${partners_indent}    ${partner.partner_debt_points_readable}` };
+        if (show_partner_memberships) { html += `<br>${partners_indent}    ${partner._memberships_readable}` };
+        if (show_partner_credor_pool) { html += `<br>${partners_indent}    ${partner._credor_pool_readable}` };
+        if (show_partner_debtor_pool) { html += `<br>${partners_indent}    ${partner._debtor_pool_readable}` };
+        if (show_partner_irrational_partner_debt_points) { html += `<br>${partners_indent}    ${partner._irrational_partner_debt_points_readable}` };
+        if (show_partner_inallocable_partner_debt_points) { html += `<br>${partners_indent}    ${partner._inallocable_partner_debt_points_readable}` };
+        if (show_partner_fund_give) { html += `<br>${partners_indent}    ${partner._fund_give_readable}` };
+        if (show_partner_fund_take) { html += `<br>${partners_indent}    ${partner._fund_take_readable}` };
+        if (show_partner_fund_agenda_give) { html += `<br>${partners_indent}    ${partner._fund_agenda_give_readable}` };
+        if (show_partner_fund_agenda_take) { html += `<br>${partners_indent}    ${partner._fund_agenda_take_readable}` };
+        if (show_partner_fund_agenda_ratio_give) { html += `<br>${partners_indent}    ${partner._fund_agenda_ratio_give_readable}` };
+        if (show_partner_fund_agenda_ratio_take) { html += `<br>${partners_indent}    ${partner._fund_agenda_ratio_take_readable}` };
+
         // html += `<br>${partners_indent}${partner.partner_name}`;
     });
     return html

--- a/src/a22_belief_viewer/static/app.js
+++ b/src/a22_belief_viewer/static/app.js
@@ -14,6 +14,17 @@ let show_partner_fund_agenda_give = false;
 let show_partner_fund_agenda_take = false;
 let show_partner_fund_agenda_ratio_give = false;
 let show_partner_fund_agenda_ratio_take = false;
+let show_partner_membership_group_title = false;
+let show_partner_membership_group_cred_points = false;
+let show_partner_membership_group_debt_points = false;
+let show_partner_membership__credor_pool = false;
+let show_partner_membership__debtor_pool = false;
+let show_partner_membership__fund_agenda_give = false;
+let show_partner_membership__fund_agenda_ratio_give = false;
+let show_partner_membership__fund_agenda_ratio_take = false;
+let show_partner_membership__fund_agenda_take = false;
+let show_partner_membership__fund_give = false;
+let show_partner_membership__fund_take = false;
 let show_planroot = true;
 let show_awardunits = false;
 let show_awardheirs = false;
@@ -69,6 +80,17 @@ document.addEventListener('DOMContentLoaded', function () {
     const show_partner_fund_agenda_takeCheckbox = document.getElementById('show_partner_fund_agenda_take')
     const show_partner_fund_agenda_ratio_giveCheckbox = document.getElementById('show_partner_fund_agenda_ratio_give')
     const show_partner_fund_agenda_ratio_takeCheckbox = document.getElementById('show_partner_fund_agenda_ratio_take')
+    const show_partner_membership_group_titleCheckbox = document.getElementById('show_partner_membership_group_title')
+    const show_partner_membership_group_cred_pointsCheckbox = document.getElementById('show_partner_membership_group_cred_points')
+    const show_partner_membership_group_debt_pointsCheckbox = document.getElementById('show_partner_membership_group_debt_points')
+    const show_partner_membership__credor_poolCheckbox = document.getElementById('show_partner_membership__credor_pool')
+    const show_partner_membership__debtor_poolCheckbox = document.getElementById('show_partner_membership__debtor_pool')
+    const show_partner_membership__fund_agenda_giveCheckbox = document.getElementById('show_partner_membership__fund_agenda_give')
+    const show_partner_membership__fund_agenda_ratio_giveCheckbox = document.getElementById('show_partner_membership__fund_agenda_ratio_give')
+    const show_partner_membership__fund_agenda_ratio_takeCheckbox = document.getElementById('show_partner_membership__fund_agenda_ratio_take')
+    const show_partner_membership__fund_agenda_takeCheckbox = document.getElementById('show_partner_membership__fund_agenda_take')
+    const show_partner_membership__fund_giveCheckbox = document.getElementById('show_partner_membership__fund_give')
+    const show_partner_membership__fund_takeCheckbox = document.getElementById('show_partner_membership__fund_take')
     const show_planrootCheckbox = document.getElementById('show_planroot');
     const show_awardunitsCheckbox = document.getElementById('show_awardunits');
     const show_awardheirsCheckbox = document.getElementById('show_awardheirs');
@@ -123,6 +145,17 @@ document.addEventListener('DOMContentLoaded', function () {
     show_partner_fund_agenda_takeCheckbox.addEventListener('change', function () { show_partner_fund_agenda_take = this.checked; renderPartnersData(); });
     show_partner_fund_agenda_ratio_giveCheckbox.addEventListener('change', function () { show_partner_fund_agenda_ratio_give = this.checked; renderPartnersData(); });
     show_partner_fund_agenda_ratio_takeCheckbox.addEventListener('change', function () { show_partner_fund_agenda_ratio_take = this.checked; renderPartnersData(); });
+    show_partner_membership_group_titleCheckbox.addEventListener('change', function () { show_partner_membership_group_title = this.checked; renderPartnersData(); });
+    show_partner_membership_group_cred_pointsCheckbox.addEventListener('change', function () { show_partner_membership_group_cred_points = this.checked; renderPartnersData(); });
+    show_partner_membership_group_debt_pointsCheckbox.addEventListener('change', function () { show_partner_membership_group_debt_points = this.checked; renderPartnersData(); });
+    show_partner_membership__credor_poolCheckbox.addEventListener('change', function () { show_partner_membership__credor_pool = this.checked; renderPartnersData(); });
+    show_partner_membership__debtor_poolCheckbox.addEventListener('change', function () { show_partner_membership__debtor_pool = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_agenda_giveCheckbox.addEventListener('change', function () { show_partner_membership__fund_agenda_give = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_agenda_ratio_giveCheckbox.addEventListener('change', function () { show_partner_membership__fund_agenda_ratio_give = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_agenda_ratio_takeCheckbox.addEventListener('change', function () { show_partner_membership__fund_agenda_ratio_take = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_agenda_takeCheckbox.addEventListener('change', function () { show_partner_membership__fund_agenda_take = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_giveCheckbox.addEventListener('change', function () { show_partner_membership__fund_give = this.checked; renderPartnersData(); });
+    show_partner_membership__fund_takeCheckbox.addEventListener('change', function () { show_partner_membership__fund_take = this.checked; renderPartnersData(); });
     show_planrootCheckbox.addEventListener('change', function () { show_planroot = this.checked; renderPlanTree(); });
     show_awardunitsCheckbox.addEventListener('change', function () { show_awardunits = this.checked; renderPlanTree(); });
     show_awardheirsCheckbox.addEventListener('change', function () { show_awardheirs = this.checked; renderPlanTree(); });
@@ -194,6 +227,8 @@ function buildPartnersHtml(partnersData) {
         return "";
     }
     const partners_indent = '&nbsp;'.repeat(2);
+    const member_title_indent = '&nbsp;'.repeat(3);
+    const membership_indent = '&nbsp;'.repeat(5);
 
     let html = '';
     Object.values(partnersData).forEach(partner => {
@@ -211,8 +246,21 @@ function buildPartnersHtml(partnersData) {
         if (show_partner_fund_agenda_take) { html += `<br>${partners_indent}    ${partner._fund_agenda_take_readable}` };
         if (show_partner_fund_agenda_ratio_give) { html += `<br>${partners_indent}    ${partner._fund_agenda_ratio_give_readable}` };
         if (show_partner_fund_agenda_ratio_take) { html += `<br>${partners_indent}    ${partner._fund_agenda_ratio_take_readable}` };
-
-        // html += `<br>${partners_indent}${partner.partner_name}`;
+        console.info(partner)
+        Object.values(partner._memberships).forEach(membership => {
+            if (show_partner_membership_group_title) { html += `<br><b>${member_title_indent}${membership.group_title_readable}</b>` };
+            if (show_partner_membership_group_cred_points) { html += `<br>${membership_indent}${membership.group_cred_points_readable}` };
+            if (show_partner_membership_group_debt_points) { html += `<br>${membership_indent}${membership.group_debt_points_readable}` };
+            if (show_partner_membership__credor_pool) { html += `<br>${membership_indent}${membership._credor_pool_readable}` };
+            if (show_partner_membership__debtor_pool) { html += `<br>${membership_indent}${membership._debtor_pool_readable}` };
+            if (show_partner_membership__fund_agenda_give) { html += `<br>${membership_indent}${membership._fund_agenda_give_readable}` };
+            if (show_partner_membership__fund_agenda_ratio_give) { html += `<br>${membership_indent}${membership._fund_agenda_ratio_give_readable}` };
+            if (show_partner_membership__fund_agenda_ratio_take) { html += `<br>${membership_indent}${membership._fund_agenda_ratio_take_readable}` };
+            if (show_partner_membership__fund_agenda_take) { html += `<br>${membership_indent}${membership._fund_agenda_take_readable}` };
+            if (show_partner_membership__fund_give) { html += `<br>${membership_indent}${membership._fund_give_readable}` };
+            if (show_partner_membership__fund_take) { html += `<br>${membership_indent}${membership._fund_take_readable}` };
+            // html += `<br>${partners_indent}${partner.partner_name}`;
+        });
     });
     return html
 }

--- a/src/a22_belief_viewer/test/test__partners_view_dict.py
+++ b/src/a22_belief_viewer/test/test__partners_view_dict.py
@@ -12,6 +12,7 @@ from src.a03_group_logic.test._util.a03_str import (
     _memberships_str,
     partner_cred_points_str,
     partner_debt_points_str,
+    partner_name_str,
 )
 from src.a06_belief_logic.belief_main import beliefunit_shop
 from src.a06_belief_logic.test._util.a06_str import _groupunits_str, partners_str
@@ -91,6 +92,7 @@ def test_get_partners_view_dict_ReturnsObj_Scenario1_partners():
     _fund_agenda_ratio_take_readable_key = add_readable(_fund_agenda_ratio_take_str())
 
     assert set(yao_partner_dict.keys()) == {
+        partner_name_str(),
         partner_cred_points_str(),
         partner_debt_points_str(),
         _memberships_str(),
@@ -120,6 +122,7 @@ def test_get_partners_view_dict_ReturnsObj_Scenario1_partners():
     }
     ypu = sue_believer.get_partner(yao_str)
     yp_dict = yao_partner_dict
+    assert ypu.partner_name == yp_dict.get(partner_name_str())
     assert ypu.partner_cred_points == yp_dict.get(partner_cred_points_str())
     assert ypu.partner_debt_points == yp_dict.get(partner_debt_points_str())
     assert ypu._memberships == yp_dict.get(_memberships_str())

--- a/src/a22_belief_viewer/test/test__partners_view_dict.py
+++ b/src/a22_belief_viewer/test/test__partners_view_dict.py
@@ -10,6 +10,9 @@ from src.a03_group_logic.test._util.a03_str import (
     _inallocable_partner_debt_points_str,
     _irrational_partner_debt_points_str,
     _memberships_str,
+    group_cred_points_str,
+    group_debt_points_str,
+    group_title_str,
     partner_cred_points_str,
     partner_debt_points_str,
     partner_name_str,
@@ -125,7 +128,6 @@ def test_get_partners_view_dict_ReturnsObj_Scenario1_partners():
     assert ypu.partner_name == yp_dict.get(partner_name_str())
     assert ypu.partner_cred_points == yp_dict.get(partner_cred_points_str())
     assert ypu.partner_debt_points == yp_dict.get(partner_debt_points_str())
-    assert ypu._memberships == yp_dict.get(_memberships_str())
     assert ypu._credor_pool == yp_dict.get(_credor_pool_str())
     assert ypu._debtor_pool == yp_dict.get(_debtor_pool_str())
     assert ypu._irrational_partner_debt_points == yp_dict.get(
@@ -204,3 +206,166 @@ def test_get_partners_view_dict_ReturnsObj_Scenario1_partners():
         yp_dict.get(_fund_agenda_ratio_take_readable_key)
         == expected__fund_agenda_ratio_take_readable
     )
+
+
+def test_get_partners_view_dict_ReturnsObj_Scenario2_memberships():
+    # ESTABLISH
+    sue_str = "Sue"
+    sue_believer = beliefunit_shop(sue_str)
+    yao_str = "Yao"
+    sue_believer.add_partnerunit(yao_str)
+    swim_str = ";swimmers"
+    yao_swim_cred_points = 311
+    yao_swim_debt_points = 313
+    yao_partnerunit = sue_believer.get_partner(yao_str)
+    yao_partnerunit.add_membership(swim_str, yao_swim_cred_points, yao_swim_debt_points)
+    sue_believer.cash_out()
+
+    # WHEN
+    partners_view_dict = get_partners_view_dict(sue_believer)
+
+    # THEN
+    assert set(partners_view_dict.keys()) == {yao_str}
+    yao_partner_dict = partners_view_dict.get(yao_str)
+    assert _memberships_str() in set(yao_partner_dict.keys())
+    yao_memberships_dict = yao_partner_dict.get(_memberships_str())
+    assert {swim_str, yao_str} == set(yao_memberships_dict.keys())
+    yao_swim_dict = yao_memberships_dict.get(swim_str)
+
+    group_title_readable_key = add_readable(group_title_str())
+    group_cred_points_readable_key = add_readable(group_cred_points_str())
+    group_debt_points_readable_key = add_readable(group_debt_points_str())
+    _credor_pool_readable_key = add_readable(_credor_pool_str())
+    _debtor_pool_readable_key = add_readable(_debtor_pool_str())
+    _fund_agenda_give_readable_key = add_readable(_fund_agenda_give_str())
+    _fund_agenda_ratio_give_readable_key = add_readable(_fund_agenda_ratio_give_str())
+    _fund_agenda_ratio_take_readable_key = add_readable(_fund_agenda_ratio_take_str())
+    _fund_agenda_take_readable_key = add_readable(_fund_agenda_take_str())
+    _fund_give_readable_key = add_readable(_fund_give_str())
+    _fund_take_readable_key = add_readable(_fund_take_str())
+    assert set(yao_swim_dict.keys()) == {
+        partner_name_str(),
+        group_title_str(),
+        group_cred_points_str(),
+        group_debt_points_str(),
+        _credor_pool_str(),
+        _debtor_pool_str(),
+        _fund_agenda_give_str(),
+        _fund_agenda_ratio_give_str(),
+        _fund_agenda_ratio_take_str(),
+        _fund_agenda_take_str(),
+        _fund_give_str(),
+        _fund_take_str(),
+        group_title_readable_key,
+        group_cred_points_readable_key,
+        group_debt_points_readable_key,
+        _credor_pool_readable_key,
+        _debtor_pool_readable_key,
+        _fund_agenda_give_readable_key,
+        _fund_agenda_ratio_give_readable_key,
+        _fund_agenda_ratio_take_readable_key,
+        _fund_agenda_take_readable_key,
+        _fund_give_readable_key,
+        _fund_take_readable_key,
+    }
+    yao_swim_mu = yao_partnerunit.get_membership(swim_str)
+    expected_group_title_readable = f"{group_title_str()}: {yao_swim_mu.group_title}"
+    expected_group_cred_points_readable = (
+        f"{group_cred_points_str()}: {yao_swim_mu.group_cred_points}"
+    )
+    expected_group_debt_points_readable = (
+        f"{group_debt_points_str()}: {yao_swim_mu.group_debt_points}"
+    )
+    expected__credor_pool_readable = f"{_credor_pool_str()}: {yao_swim_mu._credor_pool}"
+    expected__debtor_pool_readable = f"{_debtor_pool_str()}: {yao_swim_mu._debtor_pool}"
+    expected__fund_agenda_give_readable = (
+        f"{_fund_agenda_give_str()}: {yao_swim_mu._fund_agenda_give}"
+    )
+    expected__fund_agenda_ratio_give_readable = (
+        f"{_fund_agenda_ratio_give_str()}: {yao_swim_mu._fund_agenda_ratio_give}"
+    )
+    expected__fund_agenda_ratio_take_readable = (
+        f"{_fund_agenda_ratio_take_str()}: {yao_swim_mu._fund_agenda_ratio_take}"
+    )
+    expected__fund_agenda_take_readable = (
+        f"{_fund_agenda_take_str()}: {yao_swim_mu._fund_agenda_take}"
+    )
+    expected__fund_give_readable = f"{_fund_give_str()}: {yao_swim_mu._fund_give}"
+    expected__fund_take_readable = f"{_fund_take_str()}: {yao_swim_mu._fund_take}"
+
+    assert yao_swim_dict.get(partner_name_str()) == yao_swim_mu.partner_name
+    assert yao_swim_dict.get(group_title_str()) == yao_swim_mu.group_title
+    assert yao_swim_dict.get(group_cred_points_str()) == yao_swim_mu.group_cred_points
+    assert yao_swim_dict.get(group_debt_points_str()) == yao_swim_mu.group_debt_points
+    assert yao_swim_dict.get(_credor_pool_str()) == yao_swim_mu._credor_pool
+    assert yao_swim_dict.get(_debtor_pool_str()) == yao_swim_mu._debtor_pool
+    assert yao_swim_dict.get(_fund_agenda_give_str()) == yao_swim_mu._fund_agenda_give
+    assert (
+        yao_swim_dict.get(_fund_agenda_ratio_give_str())
+        == yao_swim_mu._fund_agenda_ratio_give
+    )
+    assert (
+        yao_swim_dict.get(_fund_agenda_ratio_take_str())
+        == yao_swim_mu._fund_agenda_ratio_take
+    )
+    assert yao_swim_dict.get(_fund_agenda_take_str()) == yao_swim_mu._fund_agenda_take
+    assert yao_swim_dict.get(_fund_give_str()) == yao_swim_mu._fund_give
+    assert yao_swim_dict.get(_fund_take_str()) == yao_swim_mu._fund_take
+    assert yao_swim_dict.get(group_title_readable_key) == expected_group_title_readable
+    assert (
+        yao_swim_dict.get(group_cred_points_readable_key)
+        == expected_group_cred_points_readable
+    )
+    assert (
+        yao_swim_dict.get(group_debt_points_readable_key)
+        == expected_group_debt_points_readable
+    )
+    assert (
+        yao_swim_dict.get(_credor_pool_readable_key) == expected__credor_pool_readable
+    )
+    assert (
+        yao_swim_dict.get(_debtor_pool_readable_key) == expected__debtor_pool_readable
+    )
+    assert (
+        yao_swim_dict.get(_fund_agenda_give_readable_key)
+        == expected__fund_agenda_give_readable
+    )
+    assert (
+        yao_swim_dict.get(_fund_agenda_ratio_give_readable_key)
+        == expected__fund_agenda_ratio_give_readable
+    )
+    assert (
+        yao_swim_dict.get(_fund_agenda_ratio_take_readable_key)
+        == expected__fund_agenda_ratio_take_readable
+    )
+    assert (
+        yao_swim_dict.get(_fund_agenda_take_readable_key)
+        == expected__fund_agenda_take_readable
+    )
+    assert yao_swim_dict.get(_fund_give_readable_key) == expected__fund_give_readable
+    assert yao_swim_dict.get(_fund_take_readable_key) == expected__fund_take_readable
+
+    # sue_str = "Sue"
+    # sue_believer = beliefunit_shop(sue_str)
+    # yao_str = "Yao"
+    # bob_str = "Bob"
+    # yao_cred_points = 110
+    # yao_debt_points = 130
+    # bob_cred_points = 230
+    # bob_debt_points = 290
+    # sue_believer.add_partnerunit(yao_str, yao_cred_points, yao_debt_points)
+    # sue_believer.add_partnerunit(bob_str, bob_cred_points, bob_debt_points)
+    # swim_str = ";swimmers"
+    # yao_swim_cred_points = 311
+    # yao_swim_debt_points = 313
+    # bob_swim_cred_points = 411
+    # bob_swim_debt_points = 413
+    # clea_str = ";cleaners"
+    # cleaners_cred_points = 511
+    # cleaners_debt_points = 513
+    # yao_partnerunit = sue_believer.get_partner(yao_str)
+    # bob_partnerunit = sue_believer.get_partner(bob_str)
+    # bob_partnerunit.add_membership(swim_str, bob_swim_cred_points, bob_swim_debt_points)
+    # yao_partnerunit.add_membership(swim_str, yao_swim_cred_points, yao_swim_debt_points)
+    # yao_partnerunit.add_membership(clea_str, cleaners_cred_points, cleaners_debt_points)
+    # sue_believer.get_partner(yao_str).add_membership()

--- a/src/a22_belief_viewer/test/test_belief_viewer_template.py
+++ b/src/a22_belief_viewer/test/test_belief_viewer_template.py
@@ -1,3 +1,18 @@
+from src.a03_group_logic.test._util.a03_str import (
+    _credor_pool_str,
+    _debtor_pool_str,
+    _fund_agenda_give_str,
+    _fund_agenda_ratio_give_str,
+    _fund_agenda_ratio_take_str,
+    _fund_agenda_take_str,
+    _fund_give_str,
+    _fund_take_str,
+    _inallocable_partner_debt_points_str,
+    _irrational_partner_debt_points_str,
+    _memberships_str,
+    partner_cred_points_str,
+    partner_debt_points_str,
+)
 from src.a05_plan_logic.test._util.a05_str import (
     _active_hx_str,
     _active_str,
@@ -46,6 +61,7 @@ from src.a06_belief_logic.test._util.a06_str import (
     factunits_str,
     parent_rope_str,
     partners_str,
+    planroot_str,
 )
 from src.a22_belief_viewer.belief_viewer_app import get_belief_viewer_template
 
@@ -96,12 +112,26 @@ def test_get_belief_viewer_template_ReturnsObj():
         parent_rope_str(),
         partners_str(),
         plan_label_str(),
+        planroot_str(),
         # problem_bool_str(),
         reasonunits_str(),
         "root",
         star_str(),
         stop_want_str(),
         task_str(),
+        partner_cred_points_str(),
+        partner_debt_points_str(),
+        f"partner{_memberships_str()}",
+        f"partner{_credor_pool_str()}",
+        f"partner{_debtor_pool_str()}",
+        f"partner{_irrational_partner_debt_points_str()}",
+        f"partner{_inallocable_partner_debt_points_str()}",
+        f"partner{_fund_give_str()}",
+        f"partner{_fund_take_str()}",
+        f"partner{_fund_agenda_give_str()}",
+        f"partner{_fund_agenda_take_str()}",
+        f"partner{_fund_agenda_ratio_give_str()}",
+        f"partner{_fund_agenda_ratio_take_str()}",
     }
 
     for expected_str in sorted(list(expected_strs_in_template)):

--- a/src/a22_belief_viewer/test/test_belief_viewer_template.py
+++ b/src/a22_belief_viewer/test/test_belief_viewer_template.py
@@ -10,6 +10,9 @@ from src.a03_group_logic.test._util.a03_str import (
     _inallocable_partner_debt_points_str,
     _irrational_partner_debt_points_str,
     _memberships_str,
+    group_cred_points_str,
+    group_debt_points_str,
+    group_title_str,
     partner_cred_points_str,
     partner_debt_points_str,
 )
@@ -132,6 +135,17 @@ def test_get_belief_viewer_template_ReturnsObj():
         f"partner{_fund_agenda_take_str()}",
         f"partner{_fund_agenda_ratio_give_str()}",
         f"partner{_fund_agenda_ratio_take_str()}",
+        f"partner_membership_{group_title_str()}",
+        f"partner_membership_{group_cred_points_str()}",
+        f"partner_membership_{group_debt_points_str()}",
+        f"partner_membership_{_credor_pool_str()}",
+        f"partner_membership_{_debtor_pool_str()}",
+        f"partner_membership_{_fund_agenda_give_str()}",
+        f"partner_membership_{_fund_agenda_ratio_give_str()}",
+        f"partner_membership_{_fund_agenda_ratio_take_str()}",
+        f"partner_membership_{_fund_agenda_take_str()}",
+        f"partner_membership_{_fund_give_str()}",
+        f"partner_membership_{_fund_take_str()}",
     }
 
     for expected_str in sorted(list(expected_strs_in_template)):


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive GUI controls and back-end support for displaying partner and membership details in the belief viewer, along with corresponding tests

New Features:
- Add checkbox controls in belief viewer UI to toggle visibility of various partner and membership properties
- Implement JS rendering functions for partners data (renderPartnersData and buildPartnersHtml) and add state variables for partner and membership attributes
- Extend back-end get_partners_view_dict to include structured membership details and readable labels for all partner and membership fields

Enhancements:
- Rename loadPlanTreeData to loadBeliefData and adjust data fetching to include partners
- Update belief viewer template to add partner controls and a dedicated partners container

Tests:
- Add detailed tests for get_partners_view_dict scenario covering membership attributes
- Update template tests to verify new partner and membership strings
- Enhance GroupUnit and Membership tests to assert default and existing attribute keys