### PR TITLE
874 create gui for calendarto do creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "workbench.colorTheme": "Default Dark Modern"
+    "workbench.colorTheme": "Default Dark+"
 }

--- a/docs/module_blurbs.md
+++ b/docs/module_blurbs.md
@@ -2,24 +2,27 @@
 
 What does each one do?
 
-- **a00_data_toolbox**: Creates a set of tools for data manipulation and analysis.
-- **a01_term_logic**: Defines the terms and plans used in the system for consistent understanding and processing.
-- **a02_finance_logic**: Defines financial rules and calculations to ensure accurate financial operations.
-- **a03_group_logic**: Defines accounts, account memberships, and groups. Groups will be produced from memberships.
-- **a04_reason_logic**: Describes what a reason and a fact is; if the reasons match the facts, then a task can be kept.
-- **a05_plan_logic**: A plan can be a task, and if its reasons match its facts, it should be kept.
+
+- **a00_data_toolbox**: Create some standard tools files files, python dictionaries, databases, and other basic programming objects.
+- **a01_term_logic**: Defines what a Rope is and required format for groups names and individual names.
+- **a02_finance_logic**: Defines tools for financial allotment to ledgers.
+- **a03_group_logic**: Defines a voice, and it's group memberships. Groups will be produced from memberships.
+- **a04_reason_logic**: Describes what a reason and a fact is; if the reasons match the facts, the Reason.status = True
+- **a05_plan_logic**: Defines PlanUnits. Plans are complicated. A plan can have sub plans, define itself as a task, define Awardees, assigned Labor, required Reasons, etc.
 - **a06_belief_logic**: A belief is a beliefunit, made of accounts and plans. All plans are connected to the central plan, which is given all the funds in a beliefunit.
 - **a07_timeline_logic**: Allows arbitrary calendars to be defined for each beliefunit with minimal configuration.
 - **a08_belief_atom_logic**: Defines the structure and behavior of beliefunit atoms, which are single units of beliefunit and plans used in a beliefunit.
 - **a09_pack_logic**: Manages the creation and organization of packs, which are collections of beliefunit atoms for building complex beliefunits.
-- **a10_belief_calc**: Expresses the calculations performed when a beliefunit is "settled" to determine final amounts for each plan and account.
-- **a11_bud_logic**: When a moment system decides to empower a beliefunit the funds must be distributed
-- **a12_hub_tools**: These tools are used to handle complex operations involving belief files, will be deprecated.
+- **a11_bud_logic**: Defines a budget and the tools necessary to create one. Budges are created when a moment system decides to empower a beliefunit with funds that must be distributed
+- **a12_hub_toolbox**: These tools are used to handle complex operations involving belief files, will be deprecated.
 - **a13_belief_listen_logic**: These tools describe how one beliefunit listens to another
 - **a14_keep_logic**: Builds a simulation that describes how much credit a healer has earned 
-- **a15_moment_logic**: A MomentUnit is a Moment system with the basic requirements: common system of time, voice tranactions ledger, etc. Importantly a Moment system must know the state of a belief's beliefunit at any time in the past. 
-- **a16_pidgin_logic**: A tool that translates words from outside language to inside language.  
+- **a15_moment_logic**: A MomentUnit is a Moment system with the basic requirements: common system of time, voice tranactions ledger, etc. Importantly a Moment system must know the state of a belief's beliefunit at any time in the past.
+- **a16_pidgin_logic**: A tool that translates words from outside language to inside language.
 - **a17_idea_logic**: idea bricks are tables of data that build moment systems and the beliefunits within them.
-- **a18_etl_toolbox**: 
-- **a19_world_logic**: *(description needed)*
-- **a20_lobby_logic**: *(description needed)*
+- **a18_etl_toolbox**: All the tools used by WorldUnits to create MomentUnits.
+- **a19_kpi_toolbox**: a18_etl_toolbox manages the base required data. This toolbox manages the analytics outcomes.
+- **a20_world_logic**: WorldUnits create and manage MomentUnits
+- **a21_lobby_logic**: Tools for comparing how changes can create different WorldUnits.
+- **a22_belief_viewer**: Tools for Visualizing BeliefUnits
+- **a98_docs_builder**: TODO replace me

--- a/docs/str_funcs.md
+++ b/docs/str_funcs.md
@@ -4,22 +4,21 @@
 - a00_data_toolbox: INSERT, UPDATE, sqlite_datatype
 - a01_term_logic: LabelTerm, NameTerm, RopeTerm, TitleTerm, knot, parent_rope
 - a02_finance_logic: fund_iota, fund_pool, magnitude, penny
-- a03_group_logic: credor_pool, debtor_pool, fund_agenda_give, fund_agenda_ratio_give, fund_agenda_ratio_take, fund_agenda_take, fund_give, fund_take, groupunits, inallocable_voice_debt_points, irrational_voice_debt_points, laborheir, memberships, parent_solo, awardee_title, awardunits, belief_name, fund_give, fund_take, give_force, group_cred_points, group_debt_points, group_title, laborunit, voice_cred_points, voice_debt_points, voice_name, party_title, respect_bit, solo, take_force
-- a04_reason_logic: active, chore, status, cases, fact_context, fact_lower, fact_state, fact_upper, factunits, moment_label, reason_active_requisite, reason_context, reason_divisor, reason_lower, reason_state, reason_upper, reasonunits
-- a05_plan_logic: active_hx, all_voice_cred, all_voice_debt, awardheirs, awardlines, descendant_task_count, factheirs, fund_cease, fund_onset, fund_ratio, gogo_calc, healerunit_ratio, is_expanded, kids, tree_level, range_evaluated, reasonheirs, stop_calc, uid, addin, begin, close, denom, fund_share, gogo_want, healer_name, healerunit, morph, numor, plan_label, plan_rope, problem_bool, star, stop_want, task
-- a06_belief_logic: keeps_buildable, keeps_justified, offtrack_fund, offtrack_kids_star_set, rational, reason_contexts, sum_healerunit_share, tree_traverse_count, ancestors, attributes, belief_voice_membership, belief_voiceunit, belief_plan_awardunit, belief_plan_factunit, belief_plan_healerunit, belief_plan_partyunit, belief_plan_reason_caseunit, belief_plan_reasonunit, belief_planunit, beliefunit, credor_respect, debtor_respect, dimen, dimens, jkeys, last_pack_id, mandate, max_tree_traverse, voice_pool, voices, planroot, tally
+- a03_group_logic: awardee_title, awardunits, belief_name, credor_pool, debtor_pool, fund_agenda_give, fund_agenda_ratio_give, fund_agenda_ratio_take, fund_agenda_take, fund_give, fund_take, give_force, group_cred_points, group_debt_points, group_title, groupunits, inallocable_voice_debt_points, irrational_voice_debt_points, laborheir, laborunit, memberships, parent_solo, party_title, rational, respect_bit, solo, take_force, voice_cred_points, voice_debt_points, voice_name
+- a04_reason_logic: active, cases, chore, fact_context, fact_lower, fact_state, fact_upper, factheirs, factunits, moment_label, reason_active_requisite, reason_context, reason_divisor, reason_lower, reason_state, reason_upper, reasonunits, status
+- a05_plan_logic: active_hx, addin, all_voice_cred, all_voice_debt, awardheirs, awardlines, begin, close, denom, descendant_task_count, fund_cease, fund_onset, fund_ratio, fund_share, gogo_calc, gogo_want, healer_name, healerunit_ratio, healerunit, is_expanded, kids, morph, numor, plan_label, plan_rope, problem_bool, range_evaluated, reasonheirs, star, stop_calc, stop_want, task, tree_level, tree_traverse_count, uid
+- a06_belief_logic: ancestors, attributes, belief_groupunit, belief_plan_awardunit, belief_plan_factunit, belief_plan_healerunit, belief_plan_partyunit, belief_plan_reason_caseunit, belief_plan_reasonunit, belief_planunit, belief_voice_membership, belief_voiceunit, beliefunit, class_type, credor_respect, debtor_respect, dimen, dimens, jkeys, jvalues, keeps_buildable, keeps_justified, last_pack_id, mandate, max_tree_traverse, offtrack_fund, offtrack_kids_star_set, planroot, reason_contexts, sum_healerunit_share, tally, voice_pool, voices
 - a07_timeline_logic: c100, c400_clean, c400_leap, c400_number, creg, cumulative_day, day, days, five, hour, hours_config, monthday_distortion, months_config, readable, time, timeline_label, timeline, week, weekdays_config, weeks, year, yr1_jan1_offset, yr4_clean, yr4_leap
-- a08_belief_atom_logic: DELETE, atom_hx, class_type, column_order, crud, jvalues, nesting_order, normal_specs, normal_table_name
+- a08_belief_atom_logic: DELETE, atom_hx, atom, column_order, crud, nesting_order, normal_specs, normal_table_name
 - a09_pack_logic: event_int, face_name
-- a10_belief_calc: belief_groupunit
-- a11_bud_logic: amount, beliefadjust, beliefevent_facts, boss_facts, bud_belief_name, bud_voice_nets, bud_time, celldepth, found_facts, offi_time, quota, tran_time
+- a11_bud_logic: amount, beliefadjust, beliefevent_facts, boss_facts, bud_belief_name, bud_time, bud_voice_nets, celldepth, found_facts, offi_time, quota, tran_time
 - a12_hub_toolbox: gut, job, moment_mstr_dir
 - a13_belief_listen_logic: 
 - a14_keep_logic: 
 - a15_moment_logic: brokerunits, cumulative_minute, hour_label, job_listen_rotations, moment_budunit, moment_paybook, moment_timeline_hour, moment_timeline_month, moment_timeline_weekday, moment_timeoffi, momentunit, month_label, paybook, weekday_label, weekday_order
-- a16_pidgin_logic: inx_knot, inx_label, inx_name, inx_rope, inx_title, map_otx2inx, otx2inx, otx_key, otx_knot, otx_label, otx_name, otx_rope, otx_title, pidgin_core, pidgin_label, pidgin_name, pidgin_rope, pidgin_title, pidginunit, unknown_str
+- a16_pidgin_logic: inx_knot, inx_label, inx_name, inx_rope, inx_title, otx2inx, otx_key, otx_knot, otx_label, otx_name, otx_rope, otx_title, pidgin_core, pidgin_label, pidgin_name, pidgin_rope, pidgin_title, pidginunit, unknown_str
 - a17_idea_logic: allowed_crud, build_order, delete_insert, delete_insert_update, delete_update, error_message, idea_category, idea_number, insert_multiple, insert_one_time, insert_update, world_name
-- a18_etl_toolbox: belief_net_amount, brick_agg, brick_raw, brick_valid, events_brick_agg, events_brick_valid, moment_event_time_agg, moment_ote1_agg, moment_voice_nets, sound_agg, sound_raw, heard_agg, heard_raw
+- a18_etl_toolbox: belief_net_amount, brick_agg, brick_raw, brick_valid, events_brick_agg, events_brick_valid, heard_agg, heard_raw, moment_event_time_agg, moment_ote1_agg, moment_voice_nets, sound_agg, sound_raw
 - a19_kpi_toolbox: moment_kpi001_voice_nets, moment_kpi002_belief_tasks
 - a20_world_logic: 
 - a21_lobby_logic: lobby_id, lobby_mstr_dir, lobbys

--- a/src/a00_data_toolbox/_ref/a00_ref.json
+++ b/src/a00_data_toolbox/_ref/a00_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Create some standard tools files files, python dictionaries, databases, and other basic programming objects.",
     "module_description": "a00_data_toolbox"
 }

--- a/src/a00_data_toolbox/_ref/a00_ref.json
+++ b/src/a00_data_toolbox/_ref/a00_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a00_data_toolbox"
+}

--- a/src/a01_term_logic/_ref/a01_ref.json
+++ b/src/a01_term_logic/_ref/a01_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a01_term_logic"
+}

--- a/src/a01_term_logic/_ref/a01_ref.json
+++ b/src/a01_term_logic/_ref/a01_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines what a Rope is and required format for groups names and individual names.",
     "module_description": "a01_term_logic"
 }

--- a/src/a02_finance_logic/_ref/a02_ref.json
+++ b/src/a02_finance_logic/_ref/a02_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a02_finance_logic"
+}

--- a/src/a02_finance_logic/_ref/a02_ref.json
+++ b/src/a02_finance_logic/_ref/a02_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines tools for financial allotment to ledgers.",
     "module_description": "a02_finance_logic"
 }

--- a/src/a03_group_logic/_ref/a03_ref.json
+++ b/src/a03_group_logic/_ref/a03_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a03_group_logic"
+}

--- a/src/a03_group_logic/_ref/a03_ref.json
+++ b/src/a03_group_logic/_ref/a03_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines a voice, and it's group memberships. Groups will be produced from memberships.",
     "module_description": "a03_group_logic"
 }

--- a/src/a04_reason_logic/_ref/a04_ref.json
+++ b/src/a04_reason_logic/_ref/a04_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a04_reason_logic"
+}

--- a/src/a04_reason_logic/_ref/a04_ref.json
+++ b/src/a04_reason_logic/_ref/a04_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Describes what a reason and a fact is; if the reasons match the facts, the Reason.status = True",
     "module_description": "a04_reason_logic"
 }

--- a/src/a05_plan_logic/_ref/a05_ref.json
+++ b/src/a05_plan_logic/_ref/a05_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines PlanUnits. Plans are complicated. A plan can have sub plans, define itself as a task, define Awardees, assigned Labor, required Reasons, etc.",
     "module_description": "a05_plan_logic"
 }

--- a/src/a05_plan_logic/_ref/a05_ref.json
+++ b/src/a05_plan_logic/_ref/a05_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a05_plan_logic"
+}

--- a/src/a06_belief_logic/_ref/a06_ref.json
+++ b/src/a06_belief_logic/_ref/a06_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "A belief is a beliefunit, made of accounts and plans. All plans are connected to the central plan, which is given all the funds in a beliefunit.",
     "module_description": "a06_belief_logic"
 }

--- a/src/a06_belief_logic/_ref/a06_ref.json
+++ b/src/a06_belief_logic/_ref/a06_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a06_belief_logic"
+}

--- a/src/a07_timeline_logic/_ref/a07_ref.json
+++ b/src/a07_timeline_logic/_ref/a07_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Allows arbitrary calendars to be defined for each beliefunit with minimal configuration.",
     "module_description": "a07_timeline_logic"
 }

--- a/src/a07_timeline_logic/_ref/a07_ref.json
+++ b/src/a07_timeline_logic/_ref/a07_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a07_timeline_logic"
+}

--- a/src/a08_belief_atom_logic/_ref/a08_ref.json
+++ b/src/a08_belief_atom_logic/_ref/a08_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines the structure and behavior of beliefunit atoms, which are single units of beliefunit and plans used in a beliefunit.",
     "module_description": "a08_belief_atom_logic"
 }

--- a/src/a08_belief_atom_logic/_ref/a08_ref.json
+++ b/src/a08_belief_atom_logic/_ref/a08_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a08_belief_atom_logic"
+}

--- a/src/a09_pack_logic/_ref/a09_ref.json
+++ b/src/a09_pack_logic/_ref/a09_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a09_pack_logic"
+}

--- a/src/a09_pack_logic/_ref/a09_ref.json
+++ b/src/a09_pack_logic/_ref/a09_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Manages the creation and organization of packs, which are collections of beliefunit atoms for building complex beliefunits.",
     "module_description": "a09_pack_logic"
 }

--- a/src/a11_bud_logic/_ref/a11_ref.json
+++ b/src/a11_bud_logic/_ref/a11_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a11_bud_logic"
+}

--- a/src/a11_bud_logic/_ref/a11_ref.json
+++ b/src/a11_bud_logic/_ref/a11_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Defines a budget and the tools necessary to create one. Budges are created when a moment system decides to empower a beliefunit with funds that must be distributed",
     "module_description": "a11_bud_logic"
 }

--- a/src/a12_hub_toolbox/_ref/a12_ref.json
+++ b/src/a12_hub_toolbox/_ref/a12_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "These tools are used to handle complex operations involving belief files, will be deprecated.",
     "module_description": "a12_hub_toolbox"
 }

--- a/src/a12_hub_toolbox/_ref/a12_ref.json
+++ b/src/a12_hub_toolbox/_ref/a12_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a12_hub_toolbox"
+}

--- a/src/a13_belief_listen_logic/_ref/a13_ref.json
+++ b/src/a13_belief_listen_logic/_ref/a13_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "These tools describe how one beliefunit listens to another",
     "module_description": "a13_belief_listen_logic"
 }

--- a/src/a13_belief_listen_logic/_ref/a13_ref.json
+++ b/src/a13_belief_listen_logic/_ref/a13_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a13_belief_listen_logic"
+}

--- a/src/a14_keep_logic/_ref/a14_ref.json
+++ b/src/a14_keep_logic/_ref/a14_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a14_keep_logic"
+}

--- a/src/a14_keep_logic/_ref/a14_ref.json
+++ b/src/a14_keep_logic/_ref/a14_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Builds a simulation that describes how much credit a healer has earned ",
     "module_description": "a14_keep_logic"
 }

--- a/src/a15_moment_logic/_ref/a15_ref.json
+++ b/src/a15_moment_logic/_ref/a15_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "A MomentUnit is a Moment system with the basic requirements: common system of time, voice tranactions ledger, etc. Importantly a Moment system must know the state of a belief's beliefunit at any time in the past.",
     "module_description": "a15_moment_logic"
 }

--- a/src/a15_moment_logic/_ref/a15_ref.json
+++ b/src/a15_moment_logic/_ref/a15_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a15_moment_logic"
+}

--- a/src/a16_pidgin_logic/_ref/a16_ref.json
+++ b/src/a16_pidgin_logic/_ref/a16_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a16_pidgin_logic"
+}

--- a/src/a16_pidgin_logic/_ref/a16_ref.json
+++ b/src/a16_pidgin_logic/_ref/a16_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "A tool that translates words from outside language to inside language.",
     "module_description": "a16_pidgin_logic"
 }

--- a/src/a17_idea_logic/_ref/a17_ref.json
+++ b/src/a17_idea_logic/_ref/a17_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a17_idea_logic"
+}

--- a/src/a17_idea_logic/_ref/a17_ref.json
+++ b/src/a17_idea_logic/_ref/a17_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "idea bricks are tables of data that build moment systems and the beliefunits within them.",
     "module_description": "a17_idea_logic"
 }

--- a/src/a18_etl_toolbox/_ref/a18_ref.json
+++ b/src/a18_etl_toolbox/_ref/a18_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "All the tools used by WorldUnits to create MomentUnits.",
     "module_description": "a18_etl_toolbox"
 }

--- a/src/a18_etl_toolbox/_ref/a18_ref.json
+++ b/src/a18_etl_toolbox/_ref/a18_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a18_etl_toolbox"
+}

--- a/src/a19_kpi_toolbox/_ref/a19_ref.json
+++ b/src/a19_kpi_toolbox/_ref/a19_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a19_kpi_toolbox"
+}

--- a/src/a19_kpi_toolbox/_ref/a19_ref.json
+++ b/src/a19_kpi_toolbox/_ref/a19_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "a18_etl_toolbox manages the base required data. This toolbox manages the analytics outcomes.",
     "module_description": "a19_kpi_toolbox"
 }

--- a/src/a20_world_logic/_ref/a20_ref.json
+++ b/src/a20_world_logic/_ref/a20_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a20_world_logic"
+}

--- a/src/a20_world_logic/_ref/a20_ref.json
+++ b/src/a20_world_logic/_ref/a20_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "WorldUnits create and manage MomentUnits",
     "module_description": "a20_world_logic"
 }

--- a/src/a21_lobby_logic/_ref/a21_ref.json
+++ b/src/a21_lobby_logic/_ref/a21_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Tools for comparing how changes can create different WorldUnits.",
     "module_description": "a21_lobby_logic"
 }

--- a/src/a21_lobby_logic/_ref/a21_ref.json
+++ b/src/a21_lobby_logic/_ref/a21_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a21_lobby_logic"
+}

--- a/src/a22_belief_viewer/_ref/a22_ref.json
+++ b/src/a22_belief_viewer/_ref/a22_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a22_belief_viewer"
+}

--- a/src/a22_belief_viewer/_ref/a22_ref.json
+++ b/src/a22_belief_viewer/_ref/a22_ref.json
@@ -1,4 +1,4 @@
 {
-    "module_blurb": "TODO replace me",
+    "module_blurb": "Tools for Visualizing BeliefUnits",
     "module_description": "a22_belief_viewer"
 }

--- a/src/a98_docs_builder/_ref/a98_ref.json
+++ b/src/a98_docs_builder/_ref/a98_ref.json
@@ -1,0 +1,4 @@
+{
+    "module_blurb": "TODO replace me",
+    "module_description": "a98_docs_builder"
+}

--- a/src/a98_docs_builder/doc_builder.py
+++ b/src/a98_docs_builder/doc_builder.py
@@ -1,5 +1,10 @@
 from ast import FunctionDef as ast_FunctionDef, parse as ast_parse, walk as ast_walk
-from src.a00_data_toolbox.file_toolbox import create_path, get_level1_dirs, save_file
+from src.a00_data_toolbox.file_toolbox import (
+    create_path,
+    get_level1_dirs,
+    open_json,
+    save_file,
+)
 
 
 def get_module_descs() -> dict[str, str]:
@@ -45,3 +50,24 @@ def get_str_funcs_md() -> str:
 def save_str_funcs_md(x_dir: str):
     str_funcs_md_path = create_path(x_dir, "str_funcs.md")
     save_file(str_funcs_md_path, None, get_str_funcs_md())
+
+
+def get_module_blurbs_md() -> str:
+    lines = ["# Module Overview\n", "What does each one do?\n", ""]
+    for module_desc, module_dir in get_module_descs().items():
+        desc_number_str = module_desc[1:3]
+        docs_dir = create_path(module_dir, "_ref")
+        module_ref_path = create_path(docs_dir, f"a{desc_number_str}_ref.json")
+        module_ref_dict = open_json(module_ref_path)
+        module_description_str = "module_description"
+        module_blurb_str = "module_blurb"
+        mod_blurb = module_ref_dict.get(module_blurb_str)
+        ref_module_desc = module_ref_dict.get(module_description_str)
+
+        lines.append(f"- **{ref_module_desc}**: {mod_blurb}")
+
+    return "\n".join(lines)
+
+
+def save_module_blurbs_md(x_dir: str):
+    save_file(x_dir, "module_blurbs.md", get_module_blurbs_md())

--- a/src/a98_docs_builder/module_eval.py
+++ b/src/a98_docs_builder/module_eval.py
@@ -1,5 +1,5 @@
 from ast import FunctionDef as ast_FunctionDef, parse as ast_parse, walk as ast_walk
-from src.a00_data_toolbox.file_toolbox import create_path, get_level1_dirs
+from src.a00_data_toolbox.file_toolbox import create_path, get_level1_dirs, save_file
 
 
 def get_module_descs() -> dict[str, str]:
@@ -40,3 +40,8 @@ def get_str_funcs_md() -> str:
         _line = f"- {module_desc}: " + ", ".join(x_list)
         func_lines.append(_line)
     return "# String Functions by Module\n\n" + "\n".join(func_lines)
+
+
+def save_str_funcs_md(x_dir: str):
+    str_funcs_md_path = create_path(x_dir, "str_funcs.md")
+    save_file(str_funcs_md_path, None, get_str_funcs_md())

--- a/src/a98_docs_builder/test/test_blurbs_md.py
+++ b/src/a98_docs_builder/test/test_blurbs_md.py
@@ -1,0 +1,31 @@
+from os.path import exists as os_path_exists
+from src.a00_data_toolbox.file_toolbox import create_path, open_file
+from src.a98_docs_builder.doc_builder import get_module_blurbs_md, save_module_blurbs_md
+from src.a98_docs_builder.test._util.a98_env import (
+    env_dir_setup_cleanup,
+    get_module_temp_dir,
+)
+
+
+def test_get_module_blurbs_md_ReturnsObj():
+    # ESTABLISH / WHEN
+    module_blurbs_md = get_module_blurbs_md()
+
+    # THEN
+    assert module_blurbs_md
+    assert module_blurbs_md.find("a03") > 0
+
+
+def test_save_module_blurbs_md_ReturnsObj(env_dir_setup_cleanup):
+    # ESTABLISH
+    temp_dir = get_module_temp_dir()
+    module_blurbs_path = create_path(temp_dir, "module_blurbs.md")
+    assert not os_path_exists(module_blurbs_path)
+
+    # WHEN
+    save_module_blurbs_md(temp_dir)
+
+    # THEN
+    assert os_path_exists(module_blurbs_path)
+    expected_module_blurbs_md = get_module_blurbs_md()
+    assert open_file(module_blurbs_path) == expected_module_blurbs_md

--- a/src/a98_docs_builder/test/test_str_func_md.py
+++ b/src/a98_docs_builder/test/test_str_func_md.py
@@ -1,7 +1,6 @@
 from os.path import exists as os_path_exists
-from pathlib import Path as pathlib_Path
-from src.a00_data_toolbox.file_toolbox import create_path, open_file, save_file
-from src.a98_docs_builder.module_eval import get_str_funcs_md, save_str_funcs_md
+from src.a00_data_toolbox.file_toolbox import create_path, open_file
+from src.a98_docs_builder.doc_builder import get_str_funcs_md, save_str_funcs_md
 from src.a98_docs_builder.test._util.a98_env import (
     env_dir_setup_cleanup,
     get_module_temp_dir,

--- a/src/a98_docs_builder/test/test_str_func_md.py
+++ b/src/a98_docs_builder/test/test_str_func_md.py
@@ -1,4 +1,11 @@
-from src.a98_docs_builder.module_eval import get_str_funcs_md
+from os.path import exists as os_path_exists
+from pathlib import Path as pathlib_Path
+from src.a00_data_toolbox.file_toolbox import create_path, open_file, save_file
+from src.a98_docs_builder.module_eval import get_str_funcs_md, save_str_funcs_md
+from src.a98_docs_builder.test._util.a98_env import (
+    env_dir_setup_cleanup,
+    get_module_temp_dir,
+)
 
 
 def test_get_str_funcs_md_SetsFile_CheckMarkdownHasAllStrFunctions():
@@ -13,7 +20,19 @@ def test_get_str_funcs_md_SetsFile_CheckMarkdownHasAllStrFunctions():
     assert event_int_index > 0
     assert a09_pack_logic_index < event_int_index
 
-    # # write to production
-    # doc_main_dir = pathlib_Path("docs")
-    # doc_main_dir.mkdir(parents=True, exist_ok=True)
-    # doc_main_dir.write_text(str_funcs_md)
+
+def test_save_str_funcs_md_SavesFile_get_str_funcs_md_ToGivenDirectory(
+    env_dir_setup_cleanup,
+):
+    # ESTABLISH
+    temp_dir = get_module_temp_dir()
+    str_funcs_md_path = create_path(temp_dir, "str_funcs.md")
+    assert not os_path_exists(str_funcs_md_path)
+
+    # WHEN
+    str_funcs_md = save_str_funcs_md(temp_dir)
+
+    # THEN
+    assert os_path_exists(str_funcs_md_path)
+    str_funcs_md = get_str_funcs_md()
+    assert open_file(str_funcs_md_path) == str_funcs_md

--- a/src/a98_docs_builder/test/test_z_rebuild_docs.py
+++ b/src/a98_docs_builder/test/test_z_rebuild_docs.py
@@ -1,0 +1,12 @@
+from src.a98_docs_builder.module_eval import save_str_funcs_md
+
+
+def test_SpecialTestThatBuildsDocs():
+    # ESTABLISH / WHEN / THEN
+    # This is a special test in that instead of asserting anything it just writes
+    # documentation to production when Pytest is run
+    # docs\a17_idea_brick_formats\ (#TODO build from test_idea_brick_formats_MarkdownFileExists)
+    # docs\idea_brick_formats.md (#TODO build from test_idea_brick_formats_MarkdownFileExists)
+    # docs\module_blurbs.md (#TODO put blurb in each module and rebuild this markdown file each run)
+    # docs\ropeterm_explanation.md (Probably leave as is)
+    save_str_funcs_md("docs")  # docs\str_funcs.md

--- a/src/a98_docs_builder/test/test_z_rebuild_docs.py
+++ b/src/a98_docs_builder/test/test_z_rebuild_docs.py
@@ -1,12 +1,13 @@
-from src.a98_docs_builder.module_eval import save_str_funcs_md
+from src.a98_docs_builder.doc_builder import save_module_blurbs_md, save_str_funcs_md
 
 
 def test_SpecialTestThatBuildsDocs():
     # ESTABLISH / WHEN / THEN
+    destination_dir = "docs"
     # This is a special test in that instead of asserting anything it just writes
     # documentation to production when Pytest is run
     # docs\a17_idea_brick_formats\ (#TODO build from test_idea_brick_formats_MarkdownFileExists)
     # docs\idea_brick_formats.md (#TODO build from test_idea_brick_formats_MarkdownFileExists)
-    # docs\module_blurbs.md (#TODO put blurb in each module and rebuild this markdown file each run)
+    save_module_blurbs_md(destination_dir)
     # docs\ropeterm_explanation.md (Probably leave as is)
-    save_str_funcs_md("docs")  # docs\str_funcs.md
+    save_str_funcs_md(destination_dir)  # docs\str_funcs.md

--- a/src/a99_module_linter/test/test_module_dirs.py
+++ b/src/a99_module_linter/test/test_module_dirs.py
@@ -174,7 +174,6 @@ def test_Modules_DocumentationBuilderFolder_ref_ExistsForEveryModule():
         assert ref_keys == {module_blurb_str, module_description_str}
         assert module_ref_dict.get(module_description_str) == module_desc
         assert module_ref_dict.get(module_blurb_str)
-    assert 1 == 2
 
 
 def test_Modules_DoNotHaveEmptyDirectories():

--- a/src/a99_module_linter/test/test_module_dirs.py
+++ b/src/a99_module_linter/test/test_module_dirs.py
@@ -1,8 +1,13 @@
 from os import listdir as os_listdir, walk as os_walk
 from os.path import basename as os_path_basename, exists as os_path_exists
 from pathlib import Path as pathlib_Path
-from src.a00_data_toolbox.file_toolbox import create_path, get_level1_dirs, open_json
-from src.a98_docs_builder.module_eval import get_module_str_functions
+from src.a00_data_toolbox.file_toolbox import (
+    create_path,
+    get_level1_dirs,
+    open_file,
+    open_json,
+)
+from src.a98_docs_builder.doc_builder import get_module_str_functions
 from src.a99_module_linter.linter import (
     check_if_module_str_funcs_is_sorted,
     check_import_objs_are_ordered,
@@ -149,7 +154,7 @@ def test_Modules_NonTestFilesDoNotHaveStringFunctionsImports():
                     assert not str(file_import[0]).endswith("_str")
 
 
-def test_Modules_DocumentationBuilderFolder_ref_ExistsForEveryModule():
+def test_Modules_ModuleReferenceFolder_ref_ExistsForEveryModule():
     """
     Test that all string-related functions in each module directory are asserted and tested.
     This test performs the following checks for each module:
@@ -159,15 +164,14 @@ def test_Modules_DocumentationBuilderFolder_ref_ExistsForEveryModule():
 
     # sourcery skip: no-loop-in-tests, no-conditionals-in-tests
     # ESTABLISH / WHEN / THEN
-    running_module_descriptions = set()
     for module_desc, module_dir in get_module_descs().items():
         desc_number_str = module_desc[1:3]
         docs_dir = create_path(module_dir, "_ref")
-        print(f"{docs_dir}")
         assert os_path_exists(docs_dir)
         module_ref_path = create_path(docs_dir, f"a{desc_number_str}_ref.json")
         assert os_path_exists(module_ref_path)
         module_ref_dict = open_json(module_ref_path)
+        # print(f"{module_ref_path} \t Items: {len(module_ref_dict)}")
         ref_keys = set(module_ref_dict.keys())
         module_description_str = "module_description"
         module_blurb_str = "module_blurb"

--- a/src/a99_module_linter/test/test_module_functions.py
+++ b/src/a99_module_linter/test/test_module_functions.py
@@ -2,7 +2,7 @@ from importlib import import_module as importlib_import_module
 from inspect import getmembers as inspect_getmembers, isfunction as inspect_isfunction
 from os.path import exists as os_path_exists
 from src.a00_data_toolbox.file_toolbox import create_path, get_dir_filenames
-from src.a98_docs_builder.module_eval import get_module_descs, get_module_str_functions
+from src.a98_docs_builder.doc_builder import get_module_descs, get_module_str_functions
 from src.a99_module_linter.linter import (
     check_all_test_functions_are_formatted,
     check_all_test_functions_have_proper_naming_format,


### PR DESCRIPTION
## Summary by Sourcery

Add a documentation builder for module blurbs and string functions, scaffold JSON reference files for all modules, and strengthen module linter tests; refactor existing doc and linter modules for consistency.

New Features:
- Add doc_builder functions to generate and save markdown for string functions and module blurbs
- Introduce reference JSON templates (_ref/*.json) for each module to store module descriptions and blurbs
- Add a special pytest test to rebuild production documentation by saving module blurbs and string functions markdown

Enhancements:
- Rename module_eval.py to doc_builder.py and update imports accordingly
- Refactor module linter to use imported helpers (re_compile, ast_parse, ast_Import, ast_NodeVisitor) for regex and AST parsing

Documentation:
- Update docs/module_blurbs.md with revised module descriptions
- Update docs/str_funcs.md with corrected listings of string functions by module

Tests:
- Add tests for save_str_funcs_md and save_module_blurbs_md to verify markdown file creation and content
- Enhance module linter tests to check string function utility test coverage, correct test folder structure, and module reference JSON validity
- Update string functions markdown tests to include save_str_funcs_md behavior