### PR TITLE
874 create gui for calendarto do creation

### DIFF
--- a/docs/chapter_blurbs.md
+++ b/docs/chapter_blurbs.md
@@ -5,7 +5,7 @@ What does each one do?
 
 - **ch00_purpose**: Introduces why Jaar has been created.
 - **ch01_data_toolbox**: Creates boring tools for computer data manipulation.
-- **ch02_rope_logic**: Defines Term Classes: Knots, Labels, RopeTerms, GroupNames, MomentLabels
+- **ch02_rope_logic**: Defines Term Classes: Knots, Labels, RopeTerms, NexusLabels
 - **ch03_finance_logic**: Defines tools for financial allotment to ledgers.
 - **ch04_voice_logic**: Defines debt and cred to Voices and Memberships to Groups.
 - **ch05_reason_logic**: Defines ReasonUnits, FactUnits, and Facts decide if a Reason status is True

--- a/docs/ropeterm_explanation.md
+++ b/docs/ropeterm_explanation.md
@@ -42,7 +42,7 @@ usa_texas_rope = ";UN;USA;Texas;"
 un_texas_rope = ";UN;Texas;"
 - **NexusLabel**: The first label in a RopeTerm. Example "UN" in ";UN;USA;Texas;"
 
-# Moments
+# Ropes that have the same Nexus can create meaning
 Consider these 3 ropes: 
 1. ;UN;USA;Texas; 
 2. ;USA;Texas;
@@ -50,7 +50,7 @@ Consider these 3 ropes:
 
 Each rope arrives at the concept of Texas in a different way and connotes something different. Now consider these UN nexus :
 
-"UN" has the nexus moment
+Here each Rope has the Nexus "UN"
 1. ;UN;France;Paris;
 2. ;UN;Germany;Berlin;
 3. ;UN;USA;Texas;Dallas;
@@ -58,8 +58,10 @@ Each rope arrives at the concept of Texas in a different way and connotes someth
 
 vs 
 
-"USA" has the nexus moment
+Here each Rope has the Nexus "USA"
 1. ;USA;UN;France;Paris;
 2. ;USA;UN;Germany;Berlin;
 3. ;USA;Texas;Dallas;
 4. ;USA;Texas;Paris;
+
+The ropes give different meaning to the concepts of Dallas and Paris

--- a/src/ch02_rope_logic/_ref/ch02_doc_builder.py
+++ b/src/ch02_rope_logic/_ref/ch02_doc_builder.py
@@ -106,7 +106,7 @@ usa_texas_rope = "{un_usa_texas_rope}"
 un_texas_rope = "{un_texas_rope}"
 - **NexusLabel**: The first label in a RopeTerm. Example "UN" in "{un_usa_texas_rope}"
 
-# Moments
+# Ropes that have the same Nexus can create meaning
 Consider these 3 ropes: 
 1. {un_usa_texas_rope} 
 2. {usa_texas_rope}
@@ -114,7 +114,7 @@ Consider these 3 ropes:
 
 Each rope arrives at the concept of Texas in a different way and connotes something different. Now consider these UN nexus :
 
-"UN" has the nexus moment
+Here each Rope has the Nexus "UN"
 1. {un_france_paris_rope}
 2. {un_germany_berlin_rope}
 3. {un_usa_texas_dallas_rope}
@@ -122,8 +122,11 @@ Each rope arrives at the concept of Texas in a different way and connotes someth
 
 vs 
 
-"USA" has the nexus moment
+Here each Rope has the Nexus "USA"
 1. {usa_un_france_paris_rope}
 2. {usa_un_germany_berlin_rope}
 3. {usa_texas_dallas_rope}
-4. {usa_texas_paris_rope}"""
+4. {usa_texas_paris_rope}
+
+The ropes give different meaning to the concepts of Dallas and Paris
+"""

--- a/src/ch02_rope_logic/_ref/ch02_keywords.py
+++ b/src/ch02_rope_logic/_ref/ch02_keywords.py
@@ -1,4 +1,4 @@
-from src.ch01_data_toolbox._ref.ch01_keywords import *
+from enum import Enum
 
 
 class Ch02Keywords(str, Enum):

--- a/src/ch02_rope_logic/_ref/ch02_ref.json
+++ b/src/ch02_rope_logic/_ref/ch02_ref.json
@@ -1,6 +1,6 @@
 {
-  "chapter_blurb": "Defines Term Classes: Knots, Labels, RopeTerms, GroupNames, MomentLabels", 
-  "chapter_content": "Defines what a Rope is and required format for groups names and individual names.", 
-  "chapter_description": "ch02_rope_logic", 
+  "chapter_blurb": "Defines Term Classes: Knots, Labels, RopeTerms, NexusLabels",
+  "chapter_content": "Defines what a Rope is and required format for groups names and individual names.",
+  "chapter_description": "ch02_rope_logic",
   "chapter_number": 2
 }

--- a/src/ch02_rope_logic/_ref/ch02_semantic_types.py
+++ b/src/ch02_rope_logic/_ref/ch02_semantic_types.py
@@ -19,7 +19,7 @@ class LabelTerm(str):
 
 
 class NexusLabel(LabelTerm):
-    """A string representation of a tree root node. Node cannot contain knot"""
+    """A string representation of a tree root node. Node cannot contain knot."""
 
     pass
 
@@ -31,6 +31,6 @@ class MomentLabel(NexusLabel):  # Created to help track the object class relatio
 
 
 class RopeTerm(str):
-    """A string representation of a tree path. LabelTerms are seperated by rope knot"""
+    """A string representation of a tree path. LabelTerms are seperated by knots."""
 
     pass

--- a/src/ch02_rope_logic/rope.py
+++ b/src/ch02_rope_logic/rope.py
@@ -2,7 +2,6 @@ from pathlib import Path as pathlib_Path
 from src.ch01_data_toolbox.file_toolbox import is_path_valid
 from src.ch02_rope_logic._ref.ch02_semantic_types import (
     LabelTerm,
-    NexusLabel,
     RopeTerm,
     default_knot_if_None,
 )
@@ -12,20 +11,12 @@ class knot_not_in_parent_rope_Exception(Exception):
     pass
 
 
-def get_default_nexus_label() -> NexusLabel:
-    return LabelTerm("YY")
-
-
 def to_rope(label: LabelTerm, knot: str = None) -> LabelTerm:
     x_knot = default_knot_if_None(knot)
     if label is None:
         return x_knot
     label = label if label.find(x_knot) == 0 else f"{x_knot}{label}"
     return label if label.endswith(x_knot) else LabelTerm(f"{label}{x_knot}")
-
-
-def get_default_nexus_rope(knot: str = None) -> str:
-    return to_rope(get_default_nexus_label(), knot)
 
 
 class init_knot_not_presentException(Exception):

--- a/src/ch02_rope_logic/test/test_rope_core.py
+++ b/src/ch02_rope_logic/test/test_rope_core.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 from platform import system as platform_system
 from pytest import raises as pytest_raises
-from src.ch02_rope_logic._ref.ch02_semantic_types import default_knot_if_None
+from src.ch02_rope_logic._ref.ch02_semantic_types import (
+    LabelTerm,
+    NexusLabel,
+    default_knot_if_None,
+)
 from src.ch02_rope_logic.rope import (
     RopeTerm,
     all_ropes_between,
@@ -10,9 +14,6 @@ from src.ch02_rope_logic.rope import (
     find_replace_rope_key_dict,
     get_all_rope_labels,
     get_ancestor_ropes,
-    get_default_nexus_rope,
-    get_default_nexus_rope as root_rope,
-    get_default_nexus_label,
     get_forefather_ropes,
     get_parent_rope,
     get_root_label_from_rope,
@@ -26,6 +27,14 @@ from src.ch02_rope_logic.rope import (
     to_rope,
     validate_labelterm,
 )
+
+
+def get_default_nexus_label() -> NexusLabel:
+    return LabelTerm("YY")
+
+
+def root_rope() -> str:
+    return create_rope(get_default_nexus_label())
 
 
 def test_to_rope_ReturnsObj_WithDefault_knot():
@@ -57,23 +66,6 @@ def test_to_rope_ReturnsObj_WithParameter_knot():
     )
     assert to_rope(s_knot, s_knot) == s_knot
     assert to_rope(None, s_knot) == s_knot
-
-
-def test_get_default_nexus_label_ReturnsObj():
-    # ESTABLISH / WHEN / THEN
-    assert get_default_nexus_label() == "YY"
-    assert get_default_nexus_label().is_label(default_knot_if_None())
-
-
-def test_get_default_nexus_rope_ReturnsObj():
-    # ESTABLISH
-    default_knot = default_knot_if_None()
-    default_root_label = get_default_nexus_label()
-    slash_knot = "/"
-
-    # WHEN / THEN
-    assert get_default_nexus_rope() == to_rope(default_root_label)
-    assert get_default_nexus_rope(slash_knot) == to_rope(default_root_label, slash_knot)
 
 
 def test_create_rope_Scenario0_RaisesErrorIfKnotNotAtPostionZeroOf_parent_rope():
@@ -431,11 +423,6 @@ def test_rope_get_forefather_ropes_ReturnsAncestorRopeTermsWithoutClean():
         root_rope(): None,
     }
     assert x_ropes == texas_forefather_ropes
-
-
-def test_rope_get_default_nexus_label_ReturnsObj():
-    # ESTABLISH / WHEN / THEN
-    assert get_default_nexus_label() == "YY"
 
 
 def test_rope_create_rope_from_labels_ReturnsObj():

--- a/src/ch02_rope_logic/test/test_term.py
+++ b/src/ch02_rope_logic/test/test_term.py
@@ -76,7 +76,7 @@ def test_NexusLabel_Exists():
     # THEN
     assert x_nexus == empty_str
     doc_str = (
-        f"A string representation of a tree root node. Node cannot contain {wx.knot}"
+        f"A string representation of a tree root node. Node cannot contain {wx.knot}."
     )
     assert inspect_getdoc(x_nexus) == doc_str
 
@@ -88,7 +88,7 @@ def test_RopeTerm_Exists():
     x_rope = RopeTerm(empty_str)
     # THEN
     assert x_rope == empty_str
-    doc_str = f"A string representation of a tree path. LabelTerms are seperated by rope {wx.knot}"
+    doc_str = f"A string representation of a tree path. LabelTerms are seperated by {wx.knot}s."
     assert inspect_getdoc(x_rope) == doc_str
 
 

--- a/src/ch03_finance_logic/_ref/ch03_keywords.py
+++ b/src/ch03_finance_logic/_ref/ch03_keywords.py
@@ -1,4 +1,4 @@
-from src.ch02_rope_logic._ref.ch02_keywords import *
+from enum import Enum
 
 
 class Ch03Keywords(str, Enum):

--- a/src/ch04_voice_logic/_ref/ch04_keywords.py
+++ b/src/ch04_voice_logic/_ref/ch04_keywords.py
@@ -1,4 +1,4 @@
-from src.ch03_finance_logic._ref.ch03_keywords import *
+from enum import Enum
 
 
 class Ch04Keywords(str, Enum):

--- a/src/ch05_reason_logic/_ref/ch05_keywords.py
+++ b/src/ch05_reason_logic/_ref/ch05_keywords.py
@@ -1,4 +1,4 @@
-from src.ch04_voice_logic._ref.ch04_keywords import *
+from enum import Enum
 
 
 class Ch05Keywords(str, Enum):

--- a/src/ch05_reason_logic/test/test_case_.py
+++ b/src/ch05_reason_logic/test/test_case_.py
@@ -1,8 +1,4 @@
-from src.ch02_rope_logic.rope import (
-    create_rope,
-    find_replace_rope_key_dict,
-    get_default_nexus_label as root_label,
-)
+from src.ch02_rope_logic.rope import create_rope, find_replace_rope_key_dict
 from src.ch05_reason_logic._ref.ch05_keywords import Ch05Keywords as wx
 from src.ch05_reason_logic.reason import (
     CaseUnit,
@@ -15,7 +11,7 @@ from src.ch05_reason_logic.reason import (
 def test_CaseUnit_Exists():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     email_str = "check email"
     email_rope = create_rope(casa_rope, email_str)
 
@@ -46,7 +42,7 @@ def test_CaseUnit_Exists():
 def test_caseunit_shop_ReturnsObj():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     email_str = "check email"
     email_rope = create_rope(casa_rope, email_str)
 
@@ -60,7 +56,7 @@ def test_caseunit_shop_ReturnsObj():
 def test_CaseUnit_clear_case_status_SetsAttrs():
     # WHEN
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     casa_case = caseunit_shop(reason_state=casa_rope)
     # THEN
     assert casa_case.status is None
@@ -79,7 +75,7 @@ def test_CaseUnit_clear_case_status_SetsAttrs():
 def test_CaseUnit_is_range_IdentifiesStatus():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
 
     # WHEN
     casa_case = caseunit_shop(reason_state=casa_rope, reason_lower=1, reason_upper=3)
@@ -102,7 +98,7 @@ def test_CaseUnit_is_range_IdentifiesStatus():
 def test_CaseUnit_is_segregate_IdentifiesSegregateStatus():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
 
     # WHEN
     casa_case = caseunit_shop(reason_state=casa_rope, reason_lower=1, reason_upper=3)
@@ -124,7 +120,7 @@ def test_CaseUnit_is_segregate_IdentifiesSegregateStatus():
 
 def test_CaseUnit_is_in_lineage_IdentifiesLineage():
     # ESTABLISH
-    nation_rope = create_rope(root_label(), "Nation-States")
+    nation_rope = create_rope("Amy23", "Nation-States")
     usa_rope = create_rope(nation_rope, "USA")
     texas_rope = create_rope(usa_rope, "Texas")
     idaho_rope = create_rope(usa_rope, "Idaho")
@@ -158,7 +154,7 @@ def test_CaseUnit_is_in_lineage_IdentifiesLineage():
 def test_CaseUnit_is_in_lineage_IdentifiesLineageWithNonDefaultKnot():
     # ESTABLISH
     slash_str = "/"
-    nation_rope = create_rope(root_label(), "Nation-States", knot=slash_str)
+    nation_rope = create_rope("Amy23", "Nation-States", knot=slash_str)
     usa_rope = create_rope(nation_rope, "USA", knot=slash_str)
     texas_rope = create_rope(usa_rope, "Texas", knot=slash_str)
     idaho_rope = create_rope(usa_rope, "Idaho", knot=slash_str)
@@ -199,7 +195,7 @@ def test_CaseUnit_is_in_lineage_IdentifiesLineageWithNonDefaultKnot():
 def test_CaseUnit_get_range_segregate_status_ReturnsStatusBoolFor_is_rangeCase():
     # ESTABLISH
     yr_str = "ced_yr"
-    yr_rope = create_rope(root_label(), yr_str)
+    yr_rope = create_rope("Amy23", yr_str)
     yr_case = caseunit_shop(reason_state=yr_rope, reason_lower=3, reason_upper=13)
 
     # WHEN / THEN
@@ -244,7 +240,7 @@ def test_CaseUnit_get_range_segregate_status_ReturnsStatusBoolFor_is_rangeCase()
 def test_CaseUnit_get_range_segregate_status_ReturnsStatusBoolForSegregateCase():
     # ESTABLISH
     yr_str = "ced_yr"
-    yr_rope = create_rope(root_label(), yr_str)
+    yr_rope = create_rope("Amy23", yr_str)
     yr_case = caseunit_shop(
         reason_state=yr_rope, reason_divisor=5, reason_lower=0, reason_upper=0
     )
@@ -281,7 +277,7 @@ def test_CaseUnit_get_range_segregate_status_ReturnsStatusBoolForSegregateCase()
 def test_CaseUnitUnit_is_range_or_segregate_ReturnsBool():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
 
     # WHEN / THEN
     wk_case = caseunit_shop(reason_state=wk_rope)
@@ -299,7 +295,7 @@ def test_CaseUnitUnit_is_range_or_segregate_ReturnsBool():
 def test_CaseUnitUnit_get_case_status_Returns_active_Boolean():
     # ESTABLISH / WHEN assumes fact is in lineage
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_case = caseunit_shop(reason_state=wk_rope)
 
     # WHEN / THEN
@@ -313,7 +309,7 @@ def test_CaseUnitUnit_get_case_status_Returns_active_Boolean():
 def test_CaseUnitUnit_get_active_Returns_is_range_active_Boolean():
     # ESTABLISH assumes fact is in lineage
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_case = caseunit_shop(reason_state=wk_rope, reason_lower=3, reason_upper=7)
 
     # WHEN / THEN
@@ -326,7 +322,7 @@ def test_CaseUnitUnit_get_active_Returns_is_range_active_Boolean():
 def test_CaseUnitUnit_set_case_status_SetsAttr_status_WhenFactUnitIsNull():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     after_str = "afternoon"
     after_rope = create_rope(wk_rope, after_str)
     case_2 = caseunit_shop(reason_state=after_rope)
@@ -343,7 +339,7 @@ def test_CaseUnitUnit_set_case_status_SetsAttr_status_WhenFactUnitIsNull():
 def test_CaseUnitUnit_set_case_status_SetsAttr_status_OfSimple():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_case = caseunit_shop(reason_state=wed_rope)
@@ -360,7 +356,7 @@ def test_CaseUnitUnit_set_case_status_SetsAttr_status_OfSimple():
 def test_CaseUnit_set_case_status_SetsAttr_status_Scenario2():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_after_str = "afternoon"
@@ -379,7 +375,7 @@ def test_CaseUnit_set_case_status_SetsAttr_status_Scenario2():
 def test_CaseUnit_set_case_status_SetsAttr_status_Scenario3():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_noon_str = "noon"
@@ -398,7 +394,7 @@ def test_CaseUnit_set_case_status_SetsAttr_status_Scenario3():
 def test_CaseUnit_set_case_status_SetsAttr_status_Scenario4():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     thu_str = "thur"
@@ -420,7 +416,7 @@ def test_CaseUnit_set_case_status_SetsAttr_status_Scenario4():
 def test_CaseUnit_set_case_status_SetsAttr_status_Scenario5():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_cloudy_str = "cloudy"
@@ -441,7 +437,7 @@ def test_CaseUnit_set_case_status_SetsAttr_status_Scenario5():
 def test_CaseUnit_set_case_status_SetsStatus_status_ScenarioClock():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     hr24_str = "24hr"
     hr24_rope = create_rope(clock_rope, hr24_str)
     hr24_case = caseunit_shop(reason_state=hr24_rope, reason_lower=7, reason_upper=7)
@@ -458,7 +454,7 @@ def test_CaseUnit_set_case_status_SetsStatus_status_ScenarioClock():
 def test_CaseUnit_get_task_status_ReturnsObjWhen_status_IsFalse():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     no_range_case = caseunit_shop(reason_state=hr24_rope)
     no_range_case.status = False
 
@@ -470,7 +466,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhen_status_IsFalse():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBool_is_range_True():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     range_5_to_31_case = caseunit_shop(
         reason_state=hr24_rope, reason_lower=5, reason_upper=31
     )
@@ -486,7 +482,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBool_is_range_True():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBool_is_range_False():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     range_5_to_31_case = caseunit_shop(
         reason_state=hr24_rope, reason_lower=5, reason_upper=31
     )
@@ -502,7 +498,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBool_is_range_False():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateFalse_01():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     o0_n0_d5_case = caseunit_shop(
         reason_state=hr24_rope, reason_divisor=5, reason_lower=0, reason_upper=0
     )
@@ -516,7 +512,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateFalse_01():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateFalse_02():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     o0_n0_d5_case = caseunit_shop(
         reason_state=hr24_rope, reason_divisor=5, reason_lower=0, reason_upper=0
     )
@@ -530,7 +526,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateFalse_02():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateTrue_01():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     o0_n0_d5_case = caseunit_shop(
         reason_state=hr24_rope, reason_divisor=5, reason_lower=0, reason_upper=0
     )
@@ -544,7 +540,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateTrue_01():
 def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateTrue_02():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     o0_n0_d5_case = caseunit_shop(
         reason_state=hr24_rope, reason_divisor=5, reason_lower=0, reason_upper=0
     )
@@ -558,7 +554,7 @@ def test_CaseUnit_get_task_status_ReturnsObjWhenBoolSegregateTrue_02():
 def test_CaseUnit_get_task_status_ReturnsObjNotNull():
     # ESTABLISH
     wk_str = "wks"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_case = caseunit_shop(reason_state=wed_rope)
@@ -574,7 +570,7 @@ def test_CaseUnit_get_task_status_ReturnsObjNotNull():
 def test_CaseUnit_set_case_status_SetsAttrs_Scenario01():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     range_2_to_7_case = caseunit_shop(
         reason_state=hr24_rope, reason_lower=2, reason_upper=7
     )
@@ -593,7 +589,7 @@ def test_CaseUnit_set_case_status_SetsAttrs_Scenario01():
 def test_CaseUnit_set_case_status_SetsAttrs_Scenario02():
     # ESTABLISH
     hr24_str = "24hr"
-    hr24_rope = create_rope(root_label(), hr24_str)
+    hr24_rope = create_rope("Amy23", hr24_str)
     range_2_to_7_case = caseunit_shop(
         reason_state=hr24_rope, reason_lower=2, reason_upper=7
     )
@@ -625,7 +621,7 @@ def test_CaseUnit_set_case_status_SetsAttrs_Scenario02():
 def test_CaseUnit_set_case_status_SetsAttrs_Scenario03():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     hr24_str = "24hr"
     hr24_rope = create_rope(clock_rope, hr24_str)
     hr24_case = caseunit_shop(reason_state=hr24_rope, reason_lower=7, reason_upper=7)
@@ -644,7 +640,7 @@ def test_CaseUnit_set_case_status_SetsAttrs_Scenario03():
 def test_CaseUnit_set_case_status_SetCEDWeekStatusFalse():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     o1_n1_d6_case = caseunit_shop(
@@ -663,7 +659,7 @@ def test_CaseUnit_set_case_status_SetCEDWeekStatusFalse():
 def test_CaseUnit_set_case_status_SetCEDWeekStatusTrue():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     wk_case = caseunit_shop(
@@ -682,7 +678,7 @@ def test_CaseUnit_set_case_status_SetCEDWeekStatusTrue():
 def test_CaseUnit_to_dict_ReturnsDictWithDvisiorAndreason_lower_reason_upper():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     wk_case = caseunit_shop(
@@ -706,7 +702,7 @@ def test_CaseUnit_to_dict_ReturnsDictWithDvisiorAndreason_lower_reason_upper():
 def test_CaseUnit_to_dict_ReturnsDictWithreason_lowerAndreason_upper():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     wk_case = caseunit_shop(reason_state=wk_rope, reason_lower=1, reason_upper=4)
@@ -723,7 +719,7 @@ def test_CaseUnit_to_dict_ReturnsDictWithreason_lowerAndreason_upper():
 def test_CaseUnit_to_dict_ReturnsDictWithOnlyRopeTerm():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     wk_case = caseunit_shop(reason_state=wk_rope)
@@ -740,7 +736,7 @@ def test_CaseUnit_to_dict_ReturnsDictWithOnlyRopeTerm():
 def test_CaseUnit_get_obj_key():
     # ESTABLISH
     clock_str = "clock"
-    clock_rope = create_rope(root_label(), clock_str)
+    clock_rope = create_rope("Amy23", clock_str)
     wk_str = "ced_wk"
     wk_rope = create_rope(clock_rope, wk_str)
     wk_case = caseunit_shop(reason_state=wk_rope)
@@ -773,7 +769,7 @@ def test_CaseUnit_find_replace_rope_casas():
 def test_cases_get_from_dict_ReturnsCompleteObj():
     # ESTABLISH
     wk_str = "wks"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     static_dict = {
         wk_rope: {
             wx.reason_state: wk_rope,
@@ -795,7 +791,7 @@ def test_cases_get_from_dict_ReturnsCompleteObj():
 def test_cases_get_from_dict_BuildsObjFromIncompleteDict():
     # ESTABLISH
     wk_str = "wks"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     static_dict = {wk_rope: {wx.reason_state: wk_rope}}
 
     # WHEN
@@ -812,7 +808,7 @@ def test_CaseUnitsUnit_set_knot_SetsAttrs():
     wk_str = "wk"
     sun_str = "Sun"
     slash_str = "/"
-    slash_wk_rope = create_rope(root_label(), wk_str, knot=slash_str)
+    slash_wk_rope = create_rope("Amy23", wk_str, knot=slash_str)
     slash_sun_rope = create_rope(slash_wk_rope, sun_str, knot=slash_str)
     sun_caseunit = caseunit_shop(slash_sun_rope, knot=slash_str)
     assert sun_caseunit.knot == slash_str
@@ -824,14 +820,14 @@ def test_CaseUnitsUnit_set_knot_SetsAttrs():
 
     # THEN
     assert sun_caseunit.knot == colon_str
-    colon_wk_rope = create_rope(root_label(), wk_str, knot=colon_str)
+    colon_wk_rope = create_rope("Amy23", wk_str, knot=colon_str)
     colon_sun_rope = create_rope(colon_wk_rope, sun_str, knot=colon_str)
     assert sun_caseunit.reason_state == colon_sun_rope
 
 
 def test_rope_find_replace_rope_key_dict_ReturnsCasesUnit_Scenario1():
     # ESTABLISH
-    casa_rope = create_rope(root_label(), "casa")
+    casa_rope = create_rope("Amy23", "casa")
     old_seasons_rope = create_rope(casa_rope, "seasons")
     old_case_x = caseunit_shop(reason_state=old_seasons_rope)
     old_cases_x = {old_case_x.reason_state: old_case_x}

--- a/src/ch05_reason_logic/test/test_fact.py
+++ b/src/ch05_reason_logic/test/test_fact.py
@@ -1,4 +1,4 @@
-from src.ch02_rope_logic.rope import create_rope, get_default_nexus_label as root_label
+from src.ch02_rope_logic.rope import create_rope
 from src.ch05_reason_logic._ref.ch05_keywords import Ch05Keywords as wx
 from src.ch05_reason_logic.reason import (
     FactCore,
@@ -32,7 +32,7 @@ def test_FactUnit_Exists():
 def test_FactUnit_DataClass_function():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
 
@@ -53,7 +53,7 @@ def test_FactUnit_DataClass_function():
 def test_FactUnit_set_range_null_SetsAttr_1():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_fact = factunit_shop(wk_rope, wk_rope, fact_lower=1.0, fact_upper=5.0)
     assert wk_fact.fact_lower == 1.0
     assert wk_fact.fact_upper == 5.0
@@ -69,9 +69,9 @@ def test_FactUnit_set_range_null_SetsAttr_1():
 def test_FactUnit_set_fact_state_to_fact_context_SetsAttr_1():
     # ESTABLISH
     floor_str = "floor"
-    floor_rope = create_rope(root_label(), floor_str)
+    floor_rope = create_rope("Amy23", floor_str)
     dirty_str = "dirty"
-    dirty_rope = create_rope(root_label(), dirty_str)
+    dirty_rope = create_rope("Amy23", dirty_str)
     floor_fact = factunit_shop(floor_rope, dirty_rope)
     assert floor_fact.fact_context == floor_rope
     assert floor_fact.fact_state == dirty_rope
@@ -87,9 +87,9 @@ def test_FactUnit_set_fact_state_to_fact_context_SetsAttr_1():
 def test_FactUnit_set_fact_state_to_fact_context_SetsAttr_2():
     # ESTABLISH
     floor_str = "floor"
-    floor_rope = create_rope(root_label(), floor_str)
+    floor_rope = create_rope("Amy23", floor_str)
     dirty_str = "dirty"
-    dirty_rope = create_rope(root_label(), dirty_str)
+    dirty_rope = create_rope("Amy23", dirty_str)
     floor_fact = factunit_shop(floor_rope, dirty_rope, 1, 6)
     assert floor_fact.fact_lower is not None
     assert floor_fact.fact_upper is not None
@@ -105,7 +105,7 @@ def test_FactUnit_set_fact_state_to_fact_context_SetsAttr_2():
 def test_FactUnit_set_attr_SetsAttr_2():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_fact = factunit_shop(wk_rope, wk_rope, fact_lower=1.0, fact_upper=5.0)
 
     # WHEN
@@ -129,7 +129,7 @@ def test_FactUnit_set_attr_SetsAttr_2():
 def test_FactUnit_to_dict_ReturnsDict():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     x_fact_lower = 35
@@ -159,7 +159,7 @@ def test_FactUnit_to_dict_ReturnsDict():
 def test_FactUnit_to_dict_ReturnsPartialDict():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     sun_fact = factunit_shop(fact_context=wk_rope, fact_state=sun_rope)
@@ -203,7 +203,7 @@ def test_FactUnit_find_replace_rope_SetsAttr():
 def test_FactUnit_get_tuple_ReturnsObj_Scenario0_reason_context_fact_state_only():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     sun_fact = factunit_shop(fact_context=wk_rope, fact_state=sun_rope)
@@ -219,7 +219,7 @@ def test_FactUnit_get_tuple_ReturnsObj_Scenario0_reason_context_fact_state_only(
 def test_FactUnit_get_tuple_ReturnsObj_Scenario1_ValuesIn_fact_lower_fact_upper():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     sun_fact_lower = 6
@@ -237,7 +237,7 @@ def test_FactUnit_get_tuple_ReturnsObj_Scenario1_ValuesIn_fact_lower_fact_upper(
 def test_get_factunit_from_tuple_ReturnsObj_Scenario0_reason_context_fact_state_only():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     sun_fact = factunit_shop(fact_context=wk_rope, fact_state=sun_rope)
@@ -254,7 +254,7 @@ def test_get_factunit_from_tuple_ReturnsObj_Scenario0_reason_context_fact_state_
 def test_get_factunit_from_tuple_ReturnsObj_Scenario1_ValuesIn_fact_lower_fact_upper():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     sun_fact_lower = 6
@@ -273,7 +273,7 @@ def test_get_factunit_from_tuple_ReturnsObj_Scenario1_ValuesIn_fact_lower_fact_u
 def test_FactHeir_IsModifiedByFactUnit():
     # ESTABLISH
     ced_min_str = "ced_minute"
-    min_rope = create_rope(root_label(), ced_min_str)
+    min_rope = create_rope("Amy23", ced_min_str)
     ced_factheir = factheir_shop(min_rope, min_rope, 10.0, 30.0)
     ced_factunit = factunit_shop(min_rope, min_rope, 20.0, 30.0)
     assert ced_factheir.fact_lower == 10
@@ -319,7 +319,7 @@ def test_FactHeir_IsModifiedByFactUnit():
 def test_FactHeir_is_range_Returns_is_range_Status():
     # ESTABLISH
     ced_min_str = "ced_minute"
-    min_rope = create_rope(root_label(), ced_min_str)
+    min_rope = create_rope("Amy23", ced_min_str)
 
     # WHEN
     x_factheir = factheir_shop(fact_context=min_rope, fact_state=min_rope)
@@ -335,7 +335,7 @@ def test_FactHeir_is_range_Returns_is_range_Status():
 def test_factheir_is_range_Returns_is_range_Status():
     # ESTABLISH
     ced_min_str = "ced_minute"
-    min_rope = create_rope(root_label(), ced_min_str)
+    min_rope = create_rope("Amy23", ced_min_str)
 
     # WHEN
     x_factheir = factheir_shop(fact_context=min_rope, fact_state=min_rope)
@@ -355,7 +355,7 @@ def test_factheir_is_range_Returns_is_range_Status():
 def test_FactCore_get_obj_key_SetsAttr():
     # ESTABLISH
     ced_min_str = "ced_minute"
-    min_rope = create_rope(root_label(), ced_min_str)
+    min_rope = create_rope("Amy23", ced_min_str)
     secs_str = "secs"
     secs_rope = create_rope(min_rope, secs_str)
 
@@ -369,7 +369,7 @@ def test_FactCore_get_obj_key_SetsAttr():
 def test_factunits_get_from_dict_BuildsObj():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     static_dict = {
@@ -393,7 +393,7 @@ def test_factunits_get_from_dict_BuildsObj():
 def test_factunits_get_from_dict_BuildsObjFromIncompleteDict():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     sun_str = "Sun"
     sun_rope = create_rope(wk_rope, sun_str)
     static_dict = {

--- a/src/ch05_reason_logic/test/test_reason_plan.py
+++ b/src/ch05_reason_logic/test/test_reason_plan.py
@@ -1,8 +1,4 @@
-from src.ch02_rope_logic.rope import (
-    create_rope,
-    default_knot_if_None,
-    get_default_nexus_label as root_label,
-)
+from src.ch02_rope_logic.rope import create_rope, default_knot_if_None
 from src.ch05_reason_logic._ref.ch05_keywords import Ch05Keywords as wx
 from src.ch05_reason_logic.reason import (
     ReasonCore,
@@ -18,7 +14,7 @@ from src.ch05_reason_logic.reason import (
 def test_ReasonCore_Exists():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_case = caseunit_shop(reason_state=wed_rope)
@@ -46,7 +42,7 @@ def test_reasoncore_shop_ReturnsAttrWith_knot():
     # ESTABLISH
     slash_str = "/"
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str, knot=slash_str)
+    casa_rope = create_rope("Amy23", casa_str, knot=slash_str)
     print(f"{casa_rope=} ")
 
     # WHEN
@@ -59,7 +55,7 @@ def test_reasoncore_shop_ReturnsAttrWith_knot():
 def test_reasonheir_shop_ReturnsObj():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
 
     # WHEN
     casa_reason = reasonheir_shop(casa_rope)
@@ -72,7 +68,7 @@ def test_reasonheir_shop_ReturnsObj():
 def test_ReasonHeir_clear_SetsAttrs():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     email_str = "check email"
     email_rope = create_rope(casa_rope, email_str)
     email_case = caseunit_shop(reason_state=email_rope)
@@ -97,7 +93,7 @@ def test_ReasonHeir_set_status_SetsStatus():
     # sourcery skip: extract-duplicate-method
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     fri_str = "fri"
     fri_rope = create_rope(wk_rope, fri_str)
     thu_str = "thur"
@@ -143,7 +139,7 @@ def test_ReasonHeir_set_status_SetsStatus():
 def test_ReasonHeir_set_status_EmptyFactSetsStatus():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_case = caseunit_shop(reason_state=wed_rope)
@@ -161,7 +157,7 @@ def test_ReasonHeir_set_status_EmptyFactSetsStatus():
 def test_ReasonHeir_set_reason_active_heir_SetsAttr():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasonheir_shop(reason_context=wk_rope)
     assert wk_reason._reason_active_heir is None
 
@@ -175,7 +171,7 @@ def test_ReasonHeir_set_reason_active_heir_SetsAttr():
 def test_ReasonHeir_set_status_BeliefTrueSetsStatusTrue():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasonheir_shop(reason_context=wk_rope, reason_active_requisite=True)
     wk_reason.set_reason_active_heir(bool_x=True)
     assert wk_reason.status is None
@@ -190,7 +186,7 @@ def test_ReasonHeir_set_status_BeliefTrueSetsStatusTrue():
 def test_ReasonHeir_set_status_BeliefFalseSetsStatusTrue():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasonheir_shop(wk_rope, reason_active_requisite=False)
     wk_reason.set_reason_active_heir(bool_x=False)
     assert wk_reason.status is None
@@ -205,7 +201,7 @@ def test_ReasonHeir_set_status_BeliefFalseSetsStatusTrue():
 def test_ReasonHeir_set_status_BeliefTrueSetsStatusFalse():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasonheir_shop(wk_rope, reason_active_requisite=True)
     wk_reason.set_reason_active_heir(bool_x=False)
     assert wk_reason.status is None
@@ -220,7 +216,7 @@ def test_ReasonHeir_set_status_BeliefTrueSetsStatusFalse():
 def test_ReasonHeir_set_status_BeliefNoneSetsStatusFalse():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasonheir_shop(wk_rope, reason_active_requisite=True)
     wk_reason.set_reason_active_heir(bool_x=None)
     assert wk_reason.status is None
@@ -235,7 +231,7 @@ def test_ReasonHeir_set_status_BeliefNoneSetsStatusFalse():
 def test_reasonunit_shop_ReturnsObj():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
 
     # WHEN
     wk_reasonunit = reasonunit_shop(wk_rope)
@@ -248,7 +244,7 @@ def test_reasonunit_shop_ReturnsObj():
 def test_ReasonUnit_to_dict_ReturnsDictWithSinglethu_caseequireds():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     wed_case = caseunit_shop(reason_state=wed_rope)
@@ -271,7 +267,7 @@ def test_ReasonUnit_to_dict_ReturnsDictWithSinglethu_caseequireds():
 def test_ReasonUnit_to_dict_ReturnsDictWith_reason_active_requisite():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason_active_requisite = True
     wk_reason = reasonunit_shop(
         wk_rope,
@@ -294,7 +290,7 @@ def test_ReasonUnit_to_dict_ReturnsDictWith_reason_active_requisite():
 def test_ReasonUnit_to_dict_ReturnsDictWithTwoCasesReasons():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wed_str = "wed"
     wed_rope = create_rope(wk_rope, wed_str)
     thu_str = "thur"
@@ -323,7 +319,7 @@ def test_ReasonUnit_to_dict_ReturnsDictWithTwoCasesReasons():
 def test_reasons_get_from_dict_ReturnsObj():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason_active_requisite = False
     wk_reasonunit = reasonunit_shop(
         wk_rope,
@@ -350,7 +346,7 @@ def test_reasons_get_from_dict_ReturnsObj():
 def test_ReasonHeir_correctSetsPledgeState():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     range_3_to_6_case = caseunit_shop(
         reason_state=wk_rope, reason_lower=3, reason_upper=6
     )
@@ -386,7 +382,7 @@ def test_ReasonHeir_correctSetsPledgeState():
 def test_ReasonCore_get_cases_count():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
 
     # WHEN
     wk_reason = reasoncore_shop(reason_context=wk_rope)
@@ -406,7 +402,7 @@ def test_ReasonCore_get_cases_count():
 def test_ReasonCore_set_case_SetsCase():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasoncore_shop(reason_context=wk_rope)
     assert wk_reason.get_cases_count() == 0
 
@@ -425,7 +421,7 @@ def test_ReasonCore_set_case_SetsCase():
 def test_ReasonCore_case_exists_ReturnsObj():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasoncore_shop(reason_context=wk_rope)
     assert not wk_reason.case_exists(wk_rope)
 
@@ -438,7 +434,7 @@ def test_ReasonCore_case_exists_ReturnsObj():
 
 def test_ReasonCore_get_single_premis_ReturnsObj():
     # ESTABLISH
-    wk_rope = create_rope(root_label(), "wk")
+    wk_rope = create_rope("Amy23", "wk")
     wk_reason = reasoncore_shop(reason_context=wk_rope)
     wk_reason.set_case(case=wk_rope, reason_lower=3, reason_upper=6)
     wk_reason.set_case(case=wk_rope, reason_lower=7, reason_upper=10)
@@ -454,7 +450,7 @@ def test_ReasonCore_get_single_premis_ReturnsObj():
 def test_ReasonCore_del_case_DeletesCase():
     # ESTABLISH
     wk_str = "wk"
-    wk_rope = create_rope(root_label(), wk_str)
+    wk_rope = create_rope("Amy23", wk_str)
     wk_reason = reasoncore_shop(reason_context=wk_rope)
     wk_reason.set_case(case=wk_rope, reason_lower=3, reason_upper=6)
     assert wk_reason.get_cases_count() == 1
@@ -501,7 +497,7 @@ def test_ReasonCore_set_knot_SetsAttrs():
     wk_str = "wk"
     sun_str = "Sun"
     slash_str = "/"
-    slash_wk_rope = create_rope(root_label(), wk_str, knot=slash_str)
+    slash_wk_rope = create_rope("Amy23", wk_str, knot=slash_str)
     slash_sun_rope = create_rope(slash_wk_rope, sun_str, knot=slash_str)
     wk_reasonunit = reasoncore_shop(slash_wk_rope, knot=slash_str)
     wk_reasonunit.set_case(slash_sun_rope)
@@ -515,7 +511,7 @@ def test_ReasonCore_set_knot_SetsAttrs():
 
     # THEN
     assert wk_reasonunit.knot == colon_str
-    colon_wk_rope = create_rope(root_label(), wk_str, knot=colon_str)
+    colon_wk_rope = create_rope("Amy23", wk_str, knot=colon_str)
     colon_sun_rope = create_rope(colon_wk_rope, sun_str, knot=colon_str)
     assert wk_reasonunit.reason_context == colon_wk_rope
     assert wk_reasonunit.cases.get(colon_sun_rope) is not None
@@ -525,7 +521,7 @@ def test_ReasonCore_set_knot_SetsAttrs():
 def test_ReasonCore_get_obj_key():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     email_str = "check email"
     email_rope = create_rope(casa_rope, email_str)
     email_case = caseunit_shop(reason_state=email_rope)

--- a/src/ch06_plan_logic/_ref/ch06_keywords.py
+++ b/src/ch06_plan_logic/_ref/ch06_keywords.py
@@ -1,4 +1,4 @@
-from src.ch05_reason_logic._ref.ch05_keywords import *
+from enum import Enum
 
 
 class Ch06Keywords(str, Enum):

--- a/src/ch07_belief_logic/_ref/ch07_keywords.py
+++ b/src/ch07_belief_logic/_ref/ch07_keywords.py
@@ -1,4 +1,4 @@
-from src.ch06_plan_logic._ref.ch06_keywords import *
+from enum import Enum
 
 
 class Ch07Keywords(str, Enum):

--- a/src/ch08_timeline_logic/_ref/ch08_keywords.py
+++ b/src/ch08_timeline_logic/_ref/ch08_keywords.py
@@ -1,4 +1,4 @@
-from src.ch07_belief_logic._ref.ch07_keywords import *
+from enum import Enum
 
 
 class Ch08Keywords(str, Enum):

--- a/src/ch08_timeline_logic/test/test_timeline_str/test_timeline_str_func.py
+++ b/src/ch08_timeline_logic/test/test_timeline_str/test_timeline_str_func.py
@@ -1,8 +1,4 @@
-from src.ch02_rope_logic.rope import (
-    create_rope,
-    default_knot_if_None,
-    get_default_nexus_label as root_label,
-)
+from src.ch02_rope_logic.rope import create_rope, default_knot_if_None
 from src.ch05_reason_logic.reason import factunit_shop, reasonunit_shop
 from src.ch07_belief_logic.belief_main import beliefunit_shop
 from src.ch08_timeline_logic._ref.ch08_keywords import Ch08Keywords as wx
@@ -17,7 +13,7 @@ from src.ch08_timeline_logic.timeline_main import add_newtimeline_planunit
 def test_get_reason_case_readable_str_ReturnsObj_Scenario0_Level1():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status casa"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     status_casa_reason = reasonunit_shop(status_casa_rope)
@@ -40,7 +36,7 @@ def test_get_reason_case_readable_str_ReturnsObj_Scenario0_Level1():
 def test_get_reason_case_readable_str_ReturnsObj_Scenario1_TwoLevel_state():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     status_casa_reason = reasonunit_shop(status_casa_rope)
@@ -68,7 +64,7 @@ def test_get_reason_case_readable_str_ReturnsObj_Scenario1_TwoLevel_state():
 def test_get_reason_case_readable_str_ReturnsObj_Scenario2_CaseRange():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     status_casa_reason = reasonunit_shop(status_casa_rope)
@@ -100,7 +96,7 @@ def test_get_reason_case_readable_str_ReturnsObj_Scenario2_CaseRange():
 def test_get_reason_case_readable_str_ReturnsObj_Scenario3_CaseRangeAnd_reason_divisor():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     status_casa_reason = reasonunit_shop(status_casa_rope)
@@ -171,7 +167,7 @@ def test_get_reason_case_readable_str_ReturnsObj_Scenario4_Time_creg():
 def test_get_fact_state_readable_str_ReturnsObj_Scenario0_Level1():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status casa"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     dirty_str = "dirty floors"
@@ -191,7 +187,7 @@ def test_get_fact_state_readable_str_ReturnsObj_Scenario0_Level1():
 def test_get_fact_state_readable_str_ReturnsObj_Scenario1_TwoLevel_state():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     status_casa_reason = reasonunit_shop(status_casa_rope)
@@ -215,7 +211,7 @@ def test_get_fact_state_readable_str_ReturnsObj_Scenario1_TwoLevel_state():
 def test_get_fact_state_readable_str_ReturnsObj_Scenario2_CaseRange():
     # ESTABLISH
     casa_str = "casa"
-    casa_rope = create_rope(root_label(), casa_str)
+    casa_rope = create_rope("Amy23", casa_str)
     status_casa_str = "status"
     status_casa_rope = create_rope(casa_rope, status_casa_str)
     non_furniture_str = "non_furniture"

--- a/src/ch09_belief_atom_logic/_ref/ch09_keywords.py
+++ b/src/ch09_belief_atom_logic/_ref/ch09_keywords.py
@@ -1,4 +1,4 @@
-from src.ch08_timeline_logic._ref.ch08_keywords import *
+from enum import Enum
 
 
 class Ch09Keywords(str, Enum):

--- a/src/ch10_pack_logic/_ref/ch10_keywords.py
+++ b/src/ch10_pack_logic/_ref/ch10_keywords.py
@@ -1,4 +1,4 @@
-from src.ch09_belief_atom_logic._ref.ch09_keywords import *
+from enum import Enum
 
 
 class Ch10Keywords(str, Enum):

--- a/src/ch11_bud_logic/_ref/ch11_keywords.py
+++ b/src/ch11_bud_logic/_ref/ch11_keywords.py
@@ -1,4 +1,4 @@
-from src.ch10_pack_logic._ref.ch10_keywords import *
+from enum import Enum
 
 
 class Ch11Keywords(str, Enum):

--- a/src/ch12_hub_toolbox/_ref/ch12_keywords.py
+++ b/src/ch12_hub_toolbox/_ref/ch12_keywords.py
@@ -1,4 +1,4 @@
-from src.ch11_bud_logic._ref.ch11_keywords import *
+from enum import Enum
 
 
 class Ch12Keywords(str, Enum):

--- a/src/ch13_belief_listen_logic/_ref/ch13_keywords.py
+++ b/src/ch13_belief_listen_logic/_ref/ch13_keywords.py
@@ -1,4 +1,4 @@
-from src.ch12_hub_toolbox._ref.ch12_keywords import *
+from enum import Enum
 
 
 class Ch13Keywords(str, Enum):

--- a/src/ch14_keep_logic/_ref/ch14_keywords.py
+++ b/src/ch14_keep_logic/_ref/ch14_keywords.py
@@ -1,4 +1,4 @@
-from src.ch13_belief_listen_logic._ref.ch13_keywords import *
+from enum import Enum
 
 
 class Ch14Keywords(str, Enum):

--- a/src/ch15_moment_logic/_ref/ch15_keywords.py
+++ b/src/ch15_moment_logic/_ref/ch15_keywords.py
@@ -1,4 +1,4 @@
-from src.ch14_keep_logic._ref.ch14_keywords import *
+from enum import Enum
 
 
 class Ch15Keywords(str, Enum):

--- a/src/ch16_translate_logic/_ref/ch16_keywords.py
+++ b/src/ch16_translate_logic/_ref/ch16_keywords.py
@@ -1,4 +1,4 @@
-from src.ch15_moment_logic._ref.ch15_keywords import *
+from enum import Enum
 
 
 class Ch16Keywords(str, Enum):

--- a/src/ch17_idea_logic/_ref/ch17_keywords.py
+++ b/src/ch17_idea_logic/_ref/ch17_keywords.py
@@ -1,4 +1,4 @@
-from src.ch16_translate_logic._ref.ch16_keywords import *
+from enum import Enum
 
 
 class Ch17Keywords(str, Enum):

--- a/src/ch18_etl_toolbox/_ref/ch18_keywords.py
+++ b/src/ch18_etl_toolbox/_ref/ch18_keywords.py
@@ -1,4 +1,4 @@
-from src.ch17_idea_logic._ref.ch17_keywords import *
+from enum import Enum
 
 
 class Ch18Keywords(str, Enum):

--- a/src/ch19_kpi_toolbox/_ref/ch19_keywords.py
+++ b/src/ch19_kpi_toolbox/_ref/ch19_keywords.py
@@ -1,5 +1,4 @@
-from src.ch18_etl_toolbox._ref.ch18_keywords import *
-from typing import Literal
+from enum import Enum
 
 
 class Ch19Keywords(str, Enum):

--- a/src/ch20_world_logic/_ref/ch20_keywords.py
+++ b/src/ch20_world_logic/_ref/ch20_keywords.py
@@ -1,4 +1,4 @@
-from src.ch19_kpi_toolbox._ref.ch19_keywords import *
+from enum import Enum
 
 
 class Ch20Keywords(str, Enum):

--- a/src/ch21_lobby_logic/_ref/ch21_keywords.py
+++ b/src/ch21_lobby_logic/_ref/ch21_keywords.py
@@ -1,4 +1,4 @@
-from src.ch20_world_logic._ref.ch20_keywords import *
+from enum import Enum
 
 
 class Ch21Keywords(str, Enum):

--- a/src/ch22_belief_viewer/_ref/ch22_keywords.py
+++ b/src/ch22_belief_viewer/_ref/ch22_keywords.py
@@ -1,4 +1,4 @@
-from src.ch21_lobby_logic._ref.ch21_keywords import *
+from enum import Enum
 
 
 class Ch22Keywords(str, Enum):

--- a/src/ch98_docs_builder/_ref/ch98_keywords.py
+++ b/src/ch98_docs_builder/_ref/ch98_keywords.py
@@ -1,4 +1,4 @@
-from src.ch22_belief_viewer._ref.ch22_keywords import *
+from enum import Enum
 
 
 class Ch98Keywords(str, Enum):

--- a/src/ch98_docs_builder/doc_builder.py
+++ b/src/ch98_docs_builder/doc_builder.py
@@ -25,9 +25,7 @@ def get_keywords_src_config() -> dict[str, dict]:
 
 
 def get_keywords_by_chapter(keywords_dict: dict[str, dict[str]]) -> dict:
-    chapters_keywords = {}
-    for chapter_num in get_chapter_num_descs().keys():
-        chapters_keywords[chapter_num] = set()
+    chapters_keywords = {ch_num: set() for ch_num in get_chapter_num_descs().keys()}
     for x_keyword, ref_dict in keywords_dict.items():
         keyworld_init_chapter_num = ref_dict.get("chapter_num")
         chapter_set = chapters_keywords.get(keyworld_init_chapter_num)
@@ -130,8 +128,7 @@ def get_keywords_by_chapter_md() -> str:
         chapter_num = int(get_chapter_desc_str_number(chapter_desc))
         chapter_keywords = keywords_by_chapter.get(chapter_num)
         chapter_keywords = sorted(list(chapter_keywords))
-        x_list = [str_func for str_func in chapter_keywords]
-        _line = f"- {chapter_desc}: " + ", ".join(x_list)
+        _line = f"- {chapter_desc}: " + ", ".join(chapter_keywords)
         func_lines.append(_line)
     return f"# {keywords_title_str}\n\n" + "\n".join(func_lines)
 

--- a/src/ch99_chapter_style/test/test_chapter_functions.py
+++ b/src/ch99_chapter_style/test/test_chapter_functions.py
@@ -193,7 +193,7 @@ def test_Chapters_KeywordsAppearWhereTheyShould():
             for keyword in not_allowed_keywords:
                 notallowed_keyword_failure_str = f"keyword {keyword} is not allowed in chapter {chapter_prefix}. It is in {file_path=}"
                 assert keyword not in file_str, notallowed_keyword_failure_str
-            print(f"{file_path=}")
+            # print(f"{file_path=}")
             excessive_imports_str = f"{file_path} has too many Keywords class imports"
             ch_class_name = f"Ch{chapter_num:02}Keywords"
             is_doc_builder_file = "doc_builder.py" in file_path
@@ -204,6 +204,11 @@ def test_Chapters_KeywordsAppearWhereTheyShould():
             enum_x = f"{file_path} Keywords Class Import is wrong, it should be {ch_class_name}"
             if "Keywords" in file_str and not is_doc_builder_file:
                 assert ch_class_name in file_str, enum_x
+
+            if file_path.find(f"\\ch{chapter_num:02}_keywords.py") > -1:
+                print(f"{file_path=}")
+                assert file_str.count("keywords import") == 0, "No imports"
+                assert file_str.count("from enum import Enum") == 1, "import Enum"
 
 
 def test_Chapters_FirstLevelFilesDoNotImportKeywords():


### PR DESCRIPTION
## Summary by Sourcery

Remove and simplify default rope nexus helpers, update tests to use explicit root label, clean up wildcard imports in keyword modules, refactor doc builder logic, and update documentation and tests to reflect these changes

Enhancements:
- Remove default nexus label and root_rope helper functions from rope logic
- Refactor doc builder to use dict comprehensions and simplify keyword grouping
- Replace wildcard imports in chapter keyword modules with direct Enum imports

Documentation:
- Clarify ropeterm documentation phrasing and update examples in both code and markdown
- Adjust chapter blurbs to reflect name change from 'RopeTerms' to 'NexusLabels'

Tests:
- Update all tests to pass explicit default nexus label 'Amy23' instead of using root_label()
- Remove obsolete tests for default nexus label and rope helpers
- Comment out unnecessary debug prints in chapter functions tests

Chores:
- Unified import and code style across multiple modules and removed trailing debug prints