### PR TITLE
1012 build the concept of time zones into the interpretation translate module

### DIFF
--- a/src/ch04_rope/test/test_rope_lasso_obj.py
+++ b/src/ch04_rope/test/test_rope_lasso_obj.py
@@ -90,4 +90,3 @@ def test_LassoUnit_make_path_ReturnsObj_Scenario0_SimpleRope():
     assert casa_path
     expected_casa_path = create_path(exx.sue, exx.casa)
     assert casa_path == expected_casa_path
-    assert casa_path == "Sue\\casa"

--- a/src/ch17_idea/idea_db_tool.py
+++ b/src/ch17_idea/idea_db_tool.py
@@ -468,7 +468,7 @@ def is_column_type_valid(df: DataFrame, column: str, sqlite_data_type: str) -> b
     elif sqlite_data_type == "REAL":
         expected_data_type = "float64"
     elif sqlite_data_type == "TEXT":
-        expected_data_type = "object"
+        expected_data_type = "str"
     else:
         raise sqlite_data_type_Exception(f"{sqlite_data_type} is not valid sqlite_type")
     if column not in df.columns:

--- a/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
+++ b/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
@@ -8,6 +8,8 @@ def test_is_column_type_valid_ReturnsObj():
     sue_bob_df = DataFrame({"Per": ["Sue", "Bob"]})
     per_dtype = sue_bob_df["Per"].dropna().infer_objects().dtype
     print(f"{per_dtype=} {"object"==per_dtype=}")
+    print(f"{str(per_dtype)=} {"object"==str(per_dtype)=}")
+    assert 1 == 2
 
     # WHEN / THEN
     assert is_column_type_valid(DataFrame({"ID": [1, 2, 3]}), "ID", "INT")

--- a/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
+++ b/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
@@ -8,8 +8,7 @@ def test_is_column_type_valid_ReturnsObj():
     sue_bob_df = DataFrame({"Per": ["Sue", "Bob"]})
     per_dtype = sue_bob_df["Per"].dropna().infer_objects().dtype
     print(f"{per_dtype=} {"object"==per_dtype=}")
-    print(f"{str(per_dtype)=} {"object"==str(per_dtype)=}")
-    assert 1 == 2
+    print(f"{str(per_dtype)=} {"str"==str(per_dtype)=}")
 
     # WHEN / THEN
     assert is_column_type_valid(DataFrame({"ID": [1, 2, 3]}), "ID", "INT")

--- a/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
+++ b/src/ch17_idea/test/test_idea_db_tool/test_brick_intake_validation.py
@@ -4,7 +4,12 @@ from src.ch17_idea.idea_db_tool import is_column_type_valid
 
 
 def test_is_column_type_valid_ReturnsObj():
-    # ESTABLISH / WHEN / THEN
+    # ESTABLISH
+    sue_bob_df = DataFrame({"Per": ["Sue", "Bob"]})
+    per_dtype = sue_bob_df["Per"].dropna().infer_objects().dtype
+    print(f"{per_dtype=} {"object"==per_dtype=}")
+
+    # WHEN / THEN
     assert is_column_type_valid(DataFrame({"ID": [1, 2, 3]}), "ID", "INT")
     assert is_column_type_valid(DataFrame({"Age": [1.5, 2.5, 3.0]}), "Age", "REAL")
     assert is_column_type_valid(DataFrame({"Per": ["Sue", "Bob"]}), "Per", "TEXT")

--- a/src/ch18_world_etl/etl_main.py
+++ b/src/ch18_world_etl/etl_main.py
@@ -873,33 +873,39 @@ def etl_spark_lesson_json_to_spark_inherited_planunits(moment_mstr_dir: str):
             sparks_dir = create_path(plan_dir, "sparks")
             prev_spark_num = None
             for spark_num in get_level1_dirs(sparks_dir):
-                prev_plan = _get_prev_spark_num_planunit(
-                    moment_mstr_dir, moment_lasso, plan_name, prev_spark_num
-                )
-                planspark_path = create_planspark_path(
-                    moment_mstr_dir, moment_lasso, plan_name, spark_num
-                )
-                spark_dir = create_plan_spark_dir_path(
-                    moment_mstr_dir, moment_lasso, plan_name, spark_num
+                prev_spark_num = create_lesson_json_and_get_spark_num(
+                    moment_mstr_dir, moment_lasso, plan_name, prev_spark_num, spark_num
                 )
 
-                spark_all_lesson_path = create_spark_all_lesson_path(
-                    moment_mstr_dir, moment_lasso, plan_name, spark_num
-                )
-                spark_lesson = get_lessonunit_from_dict(
-                    open_json(spark_all_lesson_path)
-                )
-                sift_delta = get_minimal_plandelta(spark_lesson._plandelta, prev_plan)
-                curr_plan = spark_lesson.get_lesson_edited_plan(prev_plan)
-                save_json(planspark_path, None, curr_plan.to_dict())
-                expressed_lesson = copy_deepcopy(spark_lesson)
-                expressed_lesson.set_plandelta(sift_delta)
-                save_json(
-                    spark_dir,
-                    "expressed_lesson.json",
-                    expressed_lesson.get_serializable_step_dict(),
-                )
-                prev_spark_num = spark_num
+
+def create_lesson_json_and_get_spark_num(
+    moment_mstr_dir, moment_lasso, plan_name, prev_spark_num, spark_num
+):
+    prev_plan = _get_prev_spark_num_planunit(
+        moment_mstr_dir, moment_lasso, plan_name, prev_spark_num
+    )
+    planspark_path = create_planspark_path(
+        moment_mstr_dir, moment_lasso, plan_name, spark_num
+    )
+    spark_dir = create_plan_spark_dir_path(
+        moment_mstr_dir, moment_lasso, plan_name, spark_num
+    )
+
+    spark_all_lesson_path = create_spark_all_lesson_path(
+        moment_mstr_dir, moment_lasso, plan_name, spark_num
+    )
+    spark_lesson = get_lessonunit_from_dict(open_json(spark_all_lesson_path))
+    sift_delta = get_minimal_plandelta(spark_lesson._plandelta, prev_plan)
+    curr_plan = spark_lesson.get_lesson_edited_plan(prev_plan)
+    save_json(planspark_path, None, curr_plan.to_dict())
+    expressed_lesson = copy_deepcopy(spark_lesson)
+    expressed_lesson.set_plandelta(sift_delta)
+    save_json(
+        spark_dir,
+        "expressed_lesson.json",
+        expressed_lesson.get_serializable_step_dict(),
+    )
+    return spark_num
 
 
 def _get_prev_spark_num_planunit(

--- a/src/ch19_world_kpi/kpi_mstr.py
+++ b/src/ch19_world_kpi/kpi_mstr.py
@@ -78,9 +78,9 @@ def create_kpi_csvs(db_path: str, dst_dir: str):
 def create_calendar_markdown_files(moment_mstr_dir: str, output_dir: str):
     set_dir(output_dir)
     moments_dir = create_path(moment_mstr_dir, "moments")
-    for moment_rope in get_level1_dirs(moments_dir):
-        moment_calendar_md_path = create_path(output_dir, f"{moment_rope}_calendar.md")
-        moment_lasso = lassounit_shop(create_rope(moment_rope))
+    for moment_label in get_level1_dirs(moments_dir):
+        moment_calendar_md_path = create_path(output_dir, f"{moment_label}_calendar.md")
+        moment_lasso = lassounit_shop(create_rope(moment_label))
         x_momentunit = get_default_path_momentunit(moment_mstr_dir, moment_lasso)
         moment_epochholder = get_moment_epochholder(x_momentunit)
         moment_year_num = moment_epochholder._year_num

--- a/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
+++ b/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
@@ -1,5 +1,10 @@
 from os.path import exists as os_path_exists
-from src.ch00_py.file_toolbox import count_files, create_path, save_json
+from src.ch00_py.file_toolbox import (
+    count_files,
+    create_path,
+    get_level1_dirs,
+    save_json,
+)
 from src.ch04_rope.rope import lassounit_shop
 from src.ch09_plan_lesson._ref.ch09_path import create_moment_json_path
 from src.ch13_time.epoch_main import epochunit_shop
@@ -44,6 +49,8 @@ def test_create_calendar_markdown_files_Senario1_CreatesFileFromMomentUnitJSON(
     save_json(a23_moment_path, None, a23_momentunit.to_dict())
     a23_calendar_md_path = create_path(output_dir, "amy23_calendar.md")
     print(f"{a23_calendar_md_path=}")
+    moments_dir = create_path(moment_mstr_dir, "moments")
+    print(f"{get_level1_dirs(moments_dir)=}")
     assert not os_path_exists(a23_calendar_md_path)
 
     # WHEN
@@ -53,6 +60,7 @@ def test_create_calendar_markdown_files_Senario1_CreatesFileFromMomentUnitJSON(
     assert os_path_exists(a23_calendar_md_path)
     expected_csv_str = get_expected_creg_year0_markdown()
     assert open(a23_calendar_md_path).read() == expected_csv_str
+    assert 1 == 2
 
 
 # def test_create_calendar_markdown_files_Senario1_Add_CreatesFile(

--- a/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
+++ b/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
@@ -47,7 +47,7 @@ def test_create_calendar_markdown_files_Senario1_CreatesFileFromMomentUnitJSON(
     a23_momentunit = momentunit_shop(exx.a23, moment_mstr_dir)
     assert a23_momentunit.epoch == epochunit_shop(get_creg_config())
     save_json(a23_moment_path, None, a23_momentunit.to_dict())
-    a23_calendar_md_path = create_path(output_dir, "amy23_calendar.md")
+    a23_calendar_md_path = create_path(output_dir, "Amy23_calendar.md")
     print(f"{a23_calendar_md_path=}")
     moments_dir = create_path(moment_mstr_dir, "moments")
     print(f"{get_level1_dirs(moments_dir)=}")

--- a/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
+++ b/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
@@ -34,7 +34,6 @@ def test_create_calendar_markdown_files_Senario1_CreatesFileFromMomentUnitJSON(
     temp_dir_setup,
 ):
     # ESTABLISH
-    fay_str = "Fay"
     temp_dir = get_temp_dir()
     moment_mstr_dir = create_path(temp_dir, "moment_mstr")
     output_dir = create_path(temp_dir, "output")

--- a/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
+++ b/src/ch19_world_kpi/test/test_markdowns/test_moment_calendars.py
@@ -60,7 +60,6 @@ def test_create_calendar_markdown_files_Senario1_CreatesFileFromMomentUnitJSON(
     assert os_path_exists(a23_calendar_md_path)
     expected_csv_str = get_expected_creg_year0_markdown()
     assert open(a23_calendar_md_path).read() == expected_csv_str
-    assert 1 == 2
 
 
 # def test_create_calendar_markdown_files_Senario1_Add_CreatesFile(


### PR DESCRIPTION
## Summary by Sourcery

Refactor lesson JSON generation into a helper, tighten column type validation for TEXT fields, and adjust moment calendar markdown generation to align with updated naming and moment directory conventions.

Bug Fixes:
- Correct expected pandas dtype mapping for SQLite TEXT columns to use string dtypes instead of generic object dtypes.
- Fix calendar markdown file naming to match the actual moment label casing used in the moments directory.

Enhancements:
- Extract lesson JSON and expressed lesson creation into a reusable helper function for spark lesson ETL processing.

Tests:
- Update and extend tests for column type validation and calendar markdown generation to reflect new dtype expectations and naming behavior.