### PR TITLE
#1070 replace "pale" with "keg"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,40 @@
-repo: https://github.com/jschalk/pale
+repo: https://github.com/jschalk/keg
 
-![pale logo](https://github.com/jschalk/pale/tree/main/logo/pale_64.png) pale
+![keg logo](https://github.com/jschalk/keg/tree/main/logo/keg_64.png) keg
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-PALE Version 0.0.0
+KEG Version 0.0.0
 
-`pale` is a python library for listening to the climate of a community.
+`keg` is a python library for listening to the climate of a community.
 
-## 0.0 About pale
+## 0.0 About keg
 
-'pale' is a tool that helps me listen to the people important to me in my life.  I hope it can help you too. Let's assume I want to listen to you. If you give me a list of things that are important to you I want to be able to take your list, combine it with the lists of all the others I am about and get a output of a list of things I should do and metrics that describe my ability to do things . pale does this for all   
+'keg' is a tool that helps me listen to the people important to me in my life.  I hope it can help you too. Let's assume I want to listen to you. If you give me a list of things that are important to you I want to be able to take your list, combine it with the lists of all the others I am about and get a output of a list of things I should do and metrics that describe my ability to do things . keg does this for all   
 
-'pale' is based on the philosohpy of Emmanuel Levinas (1906-1995) as expressed in his book "Totality and Infinity: An Essay on Exteriority" (translated by Lingis, 1969) and taught to me by Jules Simon PhD (born 1959) Professor at The University of Texas at El Paso (UTEP). I took Jules's course "Levinas: Phenomenology of the Ethical" in 2014 and am still working through the implications. The most important idea that motivated pale was how Levinas describes murder as the act of not listening. It is painful to really listen, to listen in such a rope as to not know what is going to be said. To take in the suffering of the Other and bring them into myself and change myself in ropes that are by definition imaginable. Because if I could imagine them then they would not be a change. By definition I'm only listening if it changes me in ropes I can't predict. 
+'keg' is based on the philosohpy of Emmanuel Levinas (1906-1995) as expressed in his book "Totality and Infinity: An Essay on Exteriority" (translated by Lingis, 1969) and taught to me by Jules Simon PhD (born 1959) Professor at The University of Texas at El Paso (UTEP). I took Jules's course "Levinas: Phenomenology of the Ethical" in 2014 and am still working through the implications. The most important idea that motivated keg was how Levinas describes murder as the act of not listening. It is painful to really listen, to listen in such a rope as to not know what is going to be said. To take in the suffering of the Other and bring them into myself and change myself in ropes that are by definition imaginable. Because if I could imagine them then they would not be a change. By definition I'm only listening if it changes me in ropes I can't predict. 
 
-So how do I listen? pale has an engine for converting the declarations (as data) into pledge lists. How to input the data? The most accessible method is using excel sheets. 
+So how do I listen? keg has an engine for converting the declarations (as data) into pledge lists. How to input the data? The most accessible method is using excel sheets. 
 
-# 0.0.1 "Moments" The foundation of pale
-For Levinas all of reality is born from the face to face encounter. The same (me) welcomes the Other through the Face. The Face of the other tells me it's suffering and it's suffering becomes me. I then MOMENT to change who I am to ease that suffering. The suffering is infinitely deep and beyond my complete understanding so when I moment to respond to that suffering I am acting with confidence that I understand what the suffering is and that I know how to respond. That confidence stops the listening process, the Moment cuts the infinite into the finite and is the foundation for a world. When that Moment is created it can create a world. Worlds can hold a infinite amount of human experience. A small subset of that is logical systems. pale is uses programming to build that logic.
+# 0.0.1 "Moments" The foundation of keg
+For Levinas all of reality is born from the face to face encounter. The same (me) welcomes the Other through the Face. The Face of the other tells me it's suffering and it's suffering becomes me. I then MOMENT to change who I am to ease that suffering. The suffering is infinitely deep and beyond my complete understanding so when I moment to respond to that suffering I am acting with confidence that I understand what the suffering is and that I know how to respond. That confidence stops the listening process, the Moment cuts the infinite into the finite and is the foundation for a world. When that Moment is created it can create a world. Worlds can hold a infinite amount of human experience. A small subset of that is logical systems. keg is uses programming to build that logic.
 
-A Moment can create a world or change a current world. Each person can only make one moment at a time so a world that has been built by multiple moments implies each moment is from a different time. pale describes the passage of time by *spark_nums*. *spark_num* is alropes an integer. 
+A Moment can create a world or change a current world. Each person can only make one moment at a time so a world that has been built by multiple moments implies each moment is from a different time. keg describes the passage of time by *spark_nums*. *spark_num* is alropes an integer. 
 
-For pale all data must have *spark_num*, *face_name*, *moment_rope*. These are the required keys.
+For keg all data must have *spark_num*, *face_name*, *moment_rope*. These are the required keys.
 
   
-## 0.1 Short introduction to pale excel sheets
+## 0.1 Short introduction to keg excel sheets
 
-`pale` is a python library for listening to the needs of my neighbors and in turn letting them know what I need. Needs can be expressed in Excel sheets that range in complexity from a simple five column single row (example below) to 10+ columns that include configuration options that are usually set to defaults. Each row is translated and used to build the "clarity" data set. Even sheet with a single row like the example 0.1.0 below can be processed by pale. 
+`keg` is a python library for listening to the needs of my neighbors and in turn letting them know what I need. Needs can be expressed in Excel sheets that range in complexity from a simple five column single row (example below) to 10+ columns that include configuration options that are usually set to defaults. Each row is translated and used to build the "clarity" data set. Even sheet with a single row like the example 0.1.0 below can be processed by keg. 
 
 # Input Example Excel file 0.1.0: fizz0.xlsx with sheet "br00000_buzz" 
 | spark_num | face_name | moment_rope | person_name | partner_name | tran_time | amount |
 |-----------|-----------|-----------|------------|-----------|-----------|--------|
 |    77     | Emmanuel  | OxboxDean |  Emmanuel  |    Dean   |    891    |  7000  |
 
-When pale processes example 0.1.0 it creates a Moment labeled "OxboxDean" that contains persons Emmanuel and Dean and a single transaction of 7000 OxboxDean from Emmanuel to Dean. Here's a metric:
+When keg processes example 0.1.0 it creates a Moment labeled "OxboxDean" that contains persons Emmanuel and Dean and a single transaction of 7000 OxboxDean from Emmanuel to Dean. Here's a metric:
 | moment_rope | person_name | moment_fund_amount | moment_fund_rank | moment_pledges |
 |--------------|---------------|--------------------|------------------|--------------|
 |  OxboxDean   |    Emmanuel   |       -7000        |         2        |       0      |
@@ -57,7 +57,7 @@ Output stance: emmanuel_stance.xlsx, sheet "br00000"
 
  -->
 
-`pale` is a python library for listening to the climate of a community. Individual 
+`keg` is a python library for listening to the climate of a community. Individual 
 positions are aggregated by a listener into a coherant agenda that can include pledges 
 to do and pledges of  of existence. Listening and acting on it.
 
@@ -70,20 +70,20 @@ Each agenda is saved as a JSON file.
 This is mostly a one man projeect. Femi has significantly helped. 
 
  
-### 1.0 Installing `pale`
+### 1.0 Installing `keg`
 
 <!-- TODO: add dependencies -->
 
-Future enhancement: `pale` can be installed using `pip`
+Future enhancement: `keg` can be installed using `pip`
 
 <!-- TODO: Get pip install to function correctly
 
-    pip install pale
+    pip install keg
 
-If you have installed `pale` before, and you should ensure `pip` downloads the latest version (rather than using cache) you can use the follow ing commands:
+If you have installed `keg` before, and you should ensure `pip` downloads the latest version (rather than using cache) you can use the follow ing commands:
 
-    pip uninstall pale
-    pip install --no-cache pale
+    pip uninstall keg
+    pip install --no-cache keg
 
 -->
 
@@ -91,7 +91,7 @@ If you have installed `pale` before, and you should ensure `pip` downloads the l
 
 <!-- TODO: Add simplest example
 
-Should examples be found in a separate repository to ensure the `pale` repository stays 
+Should examples be found in a separate repository to ensure the `keg` repository stays 
 relatively small, whilst still providing a thorough knowledgebase of code-samples, 
 screenshots and elucidatory text.
 
@@ -131,11 +131,11 @@ PersonUnit PlanUnit FactHeir objects1
 
 ## 1.3 Test-Driven-Development
 
-pale was developed using Test-Driven-Development so every feature should have a test. 
+keg was developed using Test-Driven-Development so every feature should have a test. 
 Tests can be hard to comprehend. Some tests have many variables and can be hard to follow.
 
 <!-- TODO: Add examples 
-Should examples be in a separate repository to ensure the `pale` repository stays 
+Should examples be in a separate repository to ensure the `keg` repository stays 
 relatively small? (whilst still providing a thorough knowledgebase of code-samples, 
 screenshots and elucidatory text.)
 -->

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 """
-Pale
+Keg
 
 A Python package for communiticating across cultures.
 """

--- a/docs/chapter_blurbs.md
+++ b/docs/chapter_blurbs.md
@@ -6,7 +6,7 @@ What does each one do?
 - **ch00_py**: Creates helper tools for OS and python data manipulation.
 - **ch01_allot**: Defines how to allot a pool number to a weighted ledger.
 - **ch02_partner**: Defines debt and cred to Partners and Memberships to Groups.
-- **ch03_labor**: Introduces why Pale has been created.
+- **ch03_labor**: Introduces Labor concept: How jtasks are assigned.
 - **ch04_rope**: Defines Term Classes: Knots, Labels, RopeTerms, FirstLabels
 - **ch05_reason**: Defines ReasonUnits, FactUnits, and Facts decide if a Reason is Active
 - **ch06_plan**: Defines PlanUnits with sub-plans, Awardees, Labor, Reasons, Facts, etc.
@@ -27,4 +27,4 @@ What does each one do?
 - **ch21_lobby**: Defines Lobby Tools for gifts, World Scenarios.
 - **ch22_finance**: Defines Finance Tools for 
 - **ch24_person_viewer**: Tools for Visualizing PersonUnits
-- **ch98_docs_builder**: Defines Tools that create Pale documentation.
+- **ch98_docs_builder**: Defines Tools that create documentation.

--- a/docs/ropeterm_breakdown.md
+++ b/docs/ropeterm_breakdown.md
@@ -4,7 +4,7 @@
 # Introduction
 Imagine all the things in the world and how they are related. Most things are not related to other things. But we as humans can create those connections. For example an apple that I eat and the moon seem completely seperate but we can create the connection arbitrarily: the apple is in an orchard, the orchard is loved by Sue, Sue loves the moon: "apple-orchard-things Sue loves-moon".
 
-There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In pale I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
+There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In keg I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
 1. My cat and her food bowl. 
 2. A mountain as a concept and Wy'East (an actual mountain).
 3. My cat and a cat you know.

--- a/docs/ropeterm_exkegation.md
+++ b/docs/ropeterm_exkegation.md
@@ -4,7 +4,7 @@
 # Introduction
 Imagine all the things in the world and how they are related. Most things are not related to other things. But we as humans can create those connections. For example an apple that I eat and the moon seem completely seperate but we can create the connection arbitrarily: the apple is in an orchard, the orchard is loved by Sue, Sue loves the moon: "apple-orchard-things Sue loves-moon".
 
-There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In pale I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
+There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In keg I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
 1. My cat and her food bowl. 
 2. A mountain as a concept and Wy'East (an actual mountain).
 3. My cat and a cat you know.

--- a/docs/ropeterm_explanation.md
+++ b/docs/ropeterm_explanation.md
@@ -4,7 +4,7 @@
 # Introduction
 Imagine all the things in the world and how they are related. Most things are not related to other things. But we as humans can create those connections. For example an apple that I eat and the moon seem completely seperate but we can create the connection arbitrarily: the apple is in an orchard, the orchard is loved by Sue, Sue loves the moon: "apple-orchard-things Sue loves-moon".
 
-There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In pale I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
+There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In keg I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
 1. My cat and her food bowl. 
 2. A mountain as a concept and Wy'East (an actual mountain).
 3. My cat and a cat you know.

--- a/main_listen.py
+++ b/main_listen.py
@@ -6,9 +6,9 @@ from sys import argv as sys_argv
 if __name__ == "__main__":
     arg0 = sys_argv[1] if len(sys_argv) > 1 else None
     # Define the old and new strings in names
-    default_output_dir = "C:/dev/pale_output"
-    default_input_dir = "C:/dev/pale_input"
-    default_working_dir = "C:/dev/pale_worlds"
+    default_output_dir = "C:/dev/keg_output"
+    default_input_dir = "C:/dev/keg_input"
+    default_working_dir = "C:/dev/keg_worlds"
 
     input_directory = ""
     output_directory = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 description = ""
 license = {text = "MIT"}
-name = "pale"
+name = "keg"
 readme = "README.md"
 requires-python = ">=3.7"
 
@@ -43,7 +43,7 @@ test = [
 # ]
 # tag_format = "v{version}"
 # upload_to_pypi = false
-# version_variable = "pale/__init__.py:__version__"
+# version_variable = "keg/__init__.py:__version__"
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/src/ch03_labor/_ref/ch03_ref.json
+++ b/src/ch03_labor/_ref/ch03_ref.json
@@ -1,6 +1,6 @@
 {
-  "chapter_blurb": "Introduces why Pale has been created.", 
-  "chapter_content": "Introduces why Pale has been created.", 
+  "chapter_blurb": "Introduces Labor concept: How jtasks are assigned.", 
+  "chapter_content": "Introduces Labor concept: How jtasks are assigned.", 
   "chapter_description": "ch03_labor", 
   "chapter_number": 3
 }

--- a/src/ch04_rope/_ref/ch04_doc_builder.py
+++ b/src/ch04_rope/_ref/ch04_doc_builder.py
@@ -68,7 +68,7 @@ def get_ropeterm_description_md() -> str:
 # Introduction
 Imagine all the things in the world and how they are related. Most things are not related to other things. But we as humans can create those connections. For example an apple that I eat and the moon seem completely seperate but we can create the connection arbitrarily: the apple is in an orchard, the orchard is loved by Sue, Sue loves the moon: "apple-orchard-things Sue loves-moon".
 
-There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In pale I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
+There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In keg I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
 1. My cat and her food bowl. 
 2. A mountain as a concept and Wy'East (an actual mountain).
 3. My cat and a cat you know.

--- a/src/ch04_rope/test/test_z_rope_doc_builder.py
+++ b/src/ch04_rope/test/test_z_rope_doc_builder.py
@@ -15,7 +15,7 @@ def test_get_ropeterm_description_md_ReturnsObj():
 # Introduction
 Imagine all the things in the world and how they are related. Most things are not related to other things. But we as humans can create those connections. For example an apple that I eat and the moon seem completely seperate but we can create the connection arbitrarily: the apple is in an orchard, the orchard is loved by Sue, Sue loves the moon: "apple-orchard-things Sue loves-moon".
 
-There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In pale I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
+There are infinitely many connections that can be possibly experienced. When we're living the infinite is open to us but only some connections are actually experienced. In keg I define terms that are connections "Ropes". Imagine there is a rope connecting all things that are related to each other. Examples:
 1. My cat and her food bowl. 
 2. A mountain as a concept and Wy'East (an actual mountain).
 3. My cat and a cat you know.

--- a/src/ch06_plan/plan.py
+++ b/src/ch06_plan/plan.py
@@ -187,7 +187,7 @@ def planattrholder_shop(
 @dataclass
 class PlanUnit:
     """
-    Represents a planual unit within pale. Can represent a pledge, a plan_task, a different plan's
+    Represents a planual unit within keg. Can represent a pledge, a plan_task, a different plan's
     reason or fact, a parent plan of other plans.
     Funds: Funds come from the parent plan and go to the child plans.
     Awards: Desribes whom the funding comes from and whome it goes to.

--- a/src/ch13_time/test/test_/test_config_creg_.py
+++ b/src/ch13_time/test/test_/test_config_creg_.py
@@ -711,7 +711,7 @@ def test_PersonUnit_create_agenda_plan_CreatesAllPersonAttributes():
     assert len(sue_person.planroot.kids) == 3
 
 
-def test_PlanCore_get_agenda_dict_ReturnsObj_BugFindAndFix_active_SettingError():  # https://github.com/jschalk/pale/issues/69
+def test_PlanCore_get_agenda_dict_ReturnsObj_BugFindAndFix_active_SettingError():  # https://github.com/jschalk/keg/issues/69
     # ESTABLISH
     sue_person = personunit_shop("Sue")
     add_time_creg_planunit(sue_person)

--- a/src/ch98_docs_builder/_ref/ch98_ref.json
+++ b/src/ch98_docs_builder/_ref/ch98_ref.json
@@ -1,6 +1,6 @@
 {
-  "chapter_blurb": "Defines Tools that create Pale documentation.", 
-  "chapter_content": "Defines Tools that create Pale documentation.", 
+  "chapter_blurb": "Defines Tools that create documentation.", 
+  "chapter_content": "Defines Tools that create documentation.", 
   "chapter_description": "ch98_docs_builder", 
   "chapter_number": 98
 }


### PR DESCRIPTION
## Summary by Sourcery

Rename the project and package from “pale” to “keg” across code, docs, and packaging metadata.

New Features:
- Standardize user-facing naming so the library is presented as “keg” instead of “pale”.

Enhancements:
- Update README and documentation text to reference the new “keg” name and repository paths.
- Adjust default input/output/working directories to use keg-specific folder names.
- Align `pyproject.toml` package name and version reference comment with the new `keg` package.
- Clarify the description of the labor chapter and documentation builder to be tool-agnostic.

Tests:
- Update rope documentation builder test expectations to use the new “keg” terminology.
- Refresh an issue reference in time-related tests to point to the new repository path.