### PR TITLE
1071 consider marimo notebook generator for complex pytests

### DIFF
--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -59,7 +59,3 @@ jobs:
             status -        `${{ job.status }}`
             Log -           `${{ steps.pytest.outputs.FAILURE_LOG }}`
           assignees: jschalk
-      #TODO:
-        #clip portion of test results with failure messages [DONE]
-        #open new issue [DONE]
-        #dump failure text into issue, add some other details

--- a/src/ch00_py/db_toolbox.py
+++ b/src/ch00_py/db_toolbox.py
@@ -87,10 +87,12 @@ def get_nonconvertible_columns(
 
 
 def create_type_reference_insert_sqlstr(
-    x_table: str, x_columns: list[str], x_values: list[str]
+    x_table: str, x_columns: list[str], x_values: list[list]
 ) -> str:
     x_str = f"""
 INSERT INTO {x_table} ("""
+
+    # Build column list
     columns_str = ""
     for x_column in x_columns:
         if columns_str == "":
@@ -99,28 +101,36 @@ INSERT INTO {x_table} ("""
         else:
             columns_str = f"""{columns_str}
 , {x_column}"""
-    values_str = ""
-    for x_value in x_values:
-        if x_value is None:
-            x_value = "NULL"
-        else:
-            try:
-                float(x_value)
-            except (ValueError, TypeError):
-                x_value = f"'{x_value}'"
 
-        if values_str == "":
-            values_str = f"""{values_str}
-  {x_value}"""
+    # Build values for multiple rows
+    rows_str = ""
+    for row in x_values:
+        values_str = ""
+        for x_value in row:
+            if x_value is None:
+                x_value = "NULL"
+            else:
+                try:
+                    float(x_value)
+                except (ValueError, TypeError):
+                    x_value = f"'{x_value}'"
+
+            if values_str == "":
+                values_str = f"""{values_str}{x_value}"""
+            else:
+                values_str = f"""{values_str}, {x_value}"""
+        if rows_str == "":
+            rows_str = f"""{rows_str}
+  ({values_str})"""
         else:
-            values_str = f"""{values_str}
-, {x_value}"""
+            rows_str = f"""{rows_str}
+, ({values_str})"""
 
     return f"""{x_str}{columns_str}
 )
-VALUES ({values_str}
-)
-;"""
+VALUES{rows_str}
+;
+"""
 
 
 def dict_factory(cursor, row):

--- a/src/ch00_py/test/dict/test__dict_tool_.py
+++ b/src/ch00_py/test/dict/test__dict_tool_.py
@@ -53,6 +53,7 @@ def test_uppercase_in_str_ReturnsObj():
     assert uppercase_in_str("") == False
     assert uppercase_in_str(" ") == False
     assert uppercase_in_str("mixed123Case")
+    assert uppercase_in_str("mixed123case") == False
 
 
 def test_uppercase_is_first_ReturnsObj():

--- a/src/ch00_py/test/tool_db/test_db_tool_.py
+++ b/src/ch00_py/test/tool_db/test_db_tool_.py
@@ -51,7 +51,7 @@ def test_sqlite_obj_str_ReturnsObj():
     assert sqlite_obj_str(None, sqlite_datatype="REAL") == "NULL"
 
 
-def test_sqlite_create_type_reference_insert_sqlstr_ReturnsObj_Scenario0_WithoutNones():
+def test_create_type_reference_insert_sqlstr_ReturnsObj_Scenario0_WithoutNones():
     # ESTABLISH
     x_table = "kubo_casas"
     eagle_id_str = "eagle_id"
@@ -61,7 +61,7 @@ def test_sqlite_create_type_reference_insert_sqlstr_ReturnsObj_Scenario0_Without
     eagle_id_value = 47
     casa_id_value = "TR34"
     casa_color_value = "red"
-    x_values = [eagle_id_value, casa_id_value, casa_color_value]
+    x_values = [[eagle_id_value, casa_id_value, casa_color_value]]
 
     # WHEN
     gen_sqlstr = create_type_reference_insert_sqlstr(x_table, x_columns, x_values)
@@ -73,17 +73,15 @@ INSERT INTO {x_table} (
 , {casa_id_str}
 , {casa_color_str}
 )
-VALUES (
-  {eagle_id_value}
-, '{casa_id_value}'
-, '{casa_color_value}'
-)
-;"""
-    print(example_sqlstr)
+VALUES
+  ({eagle_id_value}, '{casa_id_value}', '{casa_color_value}')
+;
+"""
+    print(gen_sqlstr)
     assert example_sqlstr == gen_sqlstr
 
 
-def test_sqlite_create_type_reference_insert_sqlstr_ReturnsObj_Scenario1_WithNones():
+def test_create_type_reference_insert_sqlstr_ReturnsObj_Scenario1_WithNones():
     # ESTABLISH
     x_table = "kubo_casas"
     eagle_id_str = "eagle_id"
@@ -92,7 +90,7 @@ def test_sqlite_create_type_reference_insert_sqlstr_ReturnsObj_Scenario1_WithNon
     x_columns = [eagle_id_str, casa_id_str, casa_color_str]
     eagle_id_value = 47.0
     casa_id_value = 34
-    x_values = [eagle_id_value, casa_id_value, None]
+    x_values = [[eagle_id_value, casa_id_value, None]]
 
     # WHEN
     gen_sqlstr = create_type_reference_insert_sqlstr(x_table, x_columns, x_values)
@@ -104,14 +102,73 @@ INSERT INTO {x_table} (
 , {casa_id_str}
 , {casa_color_str}
 )
-VALUES (
-  {eagle_id_value}
-, {casa_id_value}
-, NULL
-)
-;"""
+VALUES
+  ({eagle_id_value}, {casa_id_value}, NULL)
+;
+"""
     print(example_sqlstr)
     assert example_sqlstr == gen_sqlstr
+
+
+def test_create_type_reference_insert_sqlstr_ReturnsObj_Scenario2_WithNones():
+    # ESTABLISH
+    x_table = "kubo_casas"
+    eagle_id_str = "eagle_id"
+    casa_id_str = "casa_id"
+    casa_color_str = "casa_color"
+    x_columns = [eagle_id_str, casa_id_str, casa_color_str]
+    eagle_id_value = 47.0
+    casa_id_value = 34
+    x_values = [
+        [eagle_id_value, casa_id_value, None],
+        [eagle_id_value + 1, casa_id_value + 1, "huh"],
+    ]
+
+    # WHEN
+    gen_sqlstr = create_type_reference_insert_sqlstr(x_table, x_columns, x_values)
+
+    # THEN
+    example_sqlstr = f"""
+INSERT INTO {x_table} (
+  {eagle_id_str}
+, {casa_id_str}
+, {casa_color_str}
+)
+VALUES
+  ({eagle_id_value}, {casa_id_value}, NULL)
+, ({eagle_id_value+1}, {casa_id_value+1}, 'huh')
+;
+"""
+    print(example_sqlstr)
+    assert example_sqlstr == gen_sqlstr
+
+
+def test_create_type_reference_insert_sqlstr_InsertsRows_Scenario0(cursor0: Cursor):
+    # ESTABLISH
+    x_table = "kubo_casas"
+    eagle_id_str = "eagle_id"
+    casa_id_str = "casa_id"
+    casa_color_str = "casa_color"
+    x_columns = [eagle_id_str, casa_id_str, casa_color_str]
+    cursor0.execute(
+        "CREATE TABLE kubo_casas (eagle_id TEXT, casa_id TEXT, casa_color TEXT)"
+    )
+    eagle_id_value = 47.0
+    casa_id_value = 34
+    x_values = [
+        [eagle_id_value, casa_id_value, None],
+        [eagle_id_value + 1, casa_id_value + 1, "huh"],
+    ]
+
+    # WHEN
+    gen_sqlstr = create_type_reference_insert_sqlstr(x_table, x_columns, x_values)
+    print(f"{gen_sqlstr}")
+    cursor0.execute(gen_sqlstr)
+
+    # THEN
+    rows = cursor0.execute(f"SELECT * FROM {x_table}").fetchall()
+    print(f"{rows=}")
+    assert rows == [("47.0", "34", None), ("48.0", "35", "huh")]
 
 
 def test_RowData_Exists():

--- a/src/ch07_person_logic/test/test_person/test__person_config.py
+++ b/src/ch07_person_logic/test/test_person/test__person_config.py
@@ -777,7 +777,6 @@ def test_get_person_config_dict_ReturnsObj_EachArgHasOne_sqlite_datatype():
         assert list(arg_types)[0] == sqlite_datatype_dict.get(x_arg), assert_failure_str
     all_args_set = set(all_args.keys())
     sqlite_args_set = set(sqlite_datatype_dict.keys())
-    # TODO figure out how to add knot to person_config
     all_args_set.add(kw.knot)
     print(sqlite_args_set.difference(all_args))
     assert all_args_set == sqlite_args_set

--- a/src/ch08_person_atom/atom_main.py
+++ b/src/ch08_person_atom/atom_main.py
@@ -56,7 +56,7 @@ class PersonAtom:
         )
         x_values = self.get_nesting_order_args()
         x_values.extend(iter(self.jvalues.values()))
-        return create_type_reference_insert_sqlstr("atom_hx", x_columns, x_values)
+        return create_type_reference_insert_sqlstr("atom_hx", x_columns, [x_values])
 
     def get_all_args_in_list(self):
         x_list = self.get_nesting_order_args()

--- a/src/ch08_person_atom/test/test_atom/test_atom_sql.py
+++ b/src/ch08_person_atom/test/test_atom/test_atom_sql.py
@@ -40,10 +40,10 @@ def test_PersonAtom_get_insert_sqlstr_ReturnsObj_PersonUnitSimpleAttrs():
 INSERT INTO {x_table} (
   {dimen}_{kw.UPDATE}_{opt_arg2}
 )
-VALUES (
-  {new2_value}
-)
-;"""
+VALUES
+  ({new2_value})
+;
+"""
 
     # WHEN / THEN
     assert x_personatom.get_insert_sqlstr() == example_sqlstr
@@ -74,12 +74,10 @@ INSERT INTO {kw.atom_hx} (
 , {x_dimen}_{kw.INSERT}_{kw.fact_context}
 , {x_dimen}_{kw.INSERT}_{kw.fact_lower}
 )
-VALUES (
-  '{ball_rope}'
-, '{knee_rope}'
-, {knee_reason_lower}
-)
-;"""
+VALUES
+  ('{ball_rope}', '{knee_rope}', {knee_reason_lower})
+;
+"""
     print(f"{generated_sqlstr=}")
     assert generated_sqlstr == example_sqlstr
 

--- a/src/ch14_moment/moment_main.py
+++ b/src/ch14_moment/moment_main.py
@@ -86,7 +86,6 @@ class MomentUnit:
     pipeline7: lessons->job (could be 5 of 6)
     """
 
-    # TODO add prefect flow decorator for each pipeline
     moment_rope: MomentRope = None
     moment_mstr_dir: str = None
     epoch: EpochUnit = None

--- a/src/ch17_idea/idea_config.py
+++ b/src/ch17_idea/idea_config.py
@@ -461,9 +461,9 @@ def get_idea_sqlite_types() -> dict[str, str]:
         "net_funds": "REAL",
         "fund_rank": "INTEGER",
         "pledges_count": "INTEGER",
-        "context_plan_close": "TEXT",
-        "context_plan_denom": "TEXT",
-        "context_plan_morph": "TEXT",
+        "context_plan_close": "REAL",
+        "context_plan_denom": "REAL",
+        "context_plan_morph": "REAL",
         "inx_epoch_diff": "INTEGER",
     }
 

--- a/src/ch18_world_etl/etl_config.py
+++ b/src/ch18_world_etl/etl_config.py
@@ -38,6 +38,32 @@ ALL_DIMEN_ABBV7 = {
     "TRLNAME",
     "TRLROPE",
     "TRLLABE",
+    "TRLCORE",
+}
+ALL_DIMEN_ABBV2 = {
+    "MP",
+    "MB",
+    "MH",
+    "MM",
+    "MW",
+    "MO",
+    "MU",
+    "PM",
+    "PT",
+    "PA",
+    "PF",
+    "PH",
+    "PC",
+    "PR",
+    "PL",
+    "PP",
+    "PU",
+    "NT",
+    "TT",
+    "TN",
+    "TR",
+    "TL",
+    "TC",
 }
 
 
@@ -66,6 +92,34 @@ def get_dimen_abbv7(dimen: str) -> str:
         "translate_rope": "TRLROPE",
         "translate_label": "TRLLABE",
         "translate_core": "TRLCORE",
+    }.get(dimen)
+
+
+def get_dimen_abbv2(dimen: str) -> str:
+    return {
+        "moment_paybook": "MP",
+        "moment_budunit": "MB",
+        "moment_epoch_hour": "MH",
+        "moment_epoch_month": "MM",
+        "moment_epoch_weekday": "MW",
+        "moment_timeoffi": "MO",
+        "momentunit": "MU",
+        "person_partner_membership": "PM",
+        "person_partnerunit": "PT",
+        "person_plan_awardunit": "PA",
+        "person_plan_factunit": "PF",
+        "person_plan_healerunit": "PH",
+        "person_plan_reason_caseunit": "PC",
+        "person_plan_reasonunit": "PR",
+        "person_plan_partyunit": "PL",
+        "person_planunit": "PP",
+        "personunit": "PU",
+        "nabu_timenum": "NT",
+        "translate_title": "TT",
+        "translate_name": "TN",
+        "translate_rope": "TR",
+        "translate_label": "TL",
+        "translate_core": "TC",
     }.get(dimen)
 
 

--- a/src/ch18_world_etl/etl_csv.py
+++ b/src/ch18_world_etl/etl_csv.py
@@ -55,8 +55,6 @@ def save_to_split_csvs(
         knot_index = column_names.index("knot")
         knot_str = collection[0][knot_index]
         x_rope = key_values[0]
-        if not knot_str:
-            knot_str = x_rope[:1]
 
         path_dirs = get_all_rope_labels(x_rope, knot_str)
         path_dirs.extend(key_values[1:])

--- a/src/ch18_world_etl/etl_main.py
+++ b/src/ch18_world_etl/etl_main.py
@@ -168,7 +168,7 @@ def etl_input_dfs_to_brick_raw_tables(cursor: sqlite3_Cursor, input_dir: str):
                 if nonconvertible_columns.get(col):
                     row_values[x_index] = None
             insert_sqlstr = create_type_reference_insert_sqlstr(
-                x_tablename, column_names, row_values
+                x_tablename, column_names, [row_values]
             )
             cursor.execute(insert_sqlstr)
 

--- a/src/ch18_world_etl/etl_sqlstr.py
+++ b/src/ch18_world_etl/etl_sqlstr.py
@@ -70,7 +70,7 @@ CREATE_PRNAWAR_SOUND_PUT_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_
 CREATE_PRNCASE_HEARD_DEL_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_del_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state_ERASE TEXT)"""
 CREATE_PRNCASE_HEARD_DEL_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_del_raw (translate_spark_num INTEGER, spark_num INTEGER, face_name_otx TEXT, face_name_inx TEXT, person_name_otx TEXT, person_name_inx TEXT, plan_rope_otx TEXT, plan_rope_inx TEXT, reason_context_otx TEXT, reason_context_inx TEXT, reason_state_ERASE_otx TEXT, reason_state_ERASE_inx TEXT)"""
 CREATE_PRNCASE_HEARD_DEL_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_del_vld (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state_ERASE TEXT)"""
-CREATE_PRNCASE_HEARD_PUT_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_put_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state TEXT, reason_lower_otx REAL, reason_lower_inx REAL, reason_upper_otx REAL, reason_upper_inx REAL, reason_divisor INTEGER, knot TEXT, context_plan_close TEXT, context_plan_denom TEXT, context_plan_morph TEXT, inx_epoch_diff INTEGER)"""
+CREATE_PRNCASE_HEARD_PUT_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_put_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state TEXT, reason_lower_otx REAL, reason_lower_inx REAL, reason_upper_otx REAL, reason_upper_inx REAL, reason_divisor INTEGER, knot TEXT, context_plan_close REAL, context_plan_denom REAL, context_plan_morph REAL, inx_epoch_diff INTEGER)"""
 CREATE_PRNCASE_HEARD_PUT_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_put_raw (translate_spark_num INTEGER, spark_num INTEGER, face_name_otx TEXT, face_name_inx TEXT, person_name_otx TEXT, person_name_inx TEXT, plan_rope_otx TEXT, plan_rope_inx TEXT, reason_context_otx TEXT, reason_context_inx TEXT, reason_state_otx TEXT, reason_state_inx TEXT, reason_lower REAL, reason_upper REAL, reason_divisor INTEGER, knot TEXT)"""
 CREATE_PRNCASE_HEARD_PUT_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_h_put_vld (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state TEXT, reason_lower REAL, reason_upper REAL, reason_divisor INTEGER, knot TEXT)"""
 CREATE_PRNCASE_SOUND_DEL_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_reason_caseunit_s_del_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, reason_context TEXT, reason_state_ERASE TEXT, error_message TEXT)"""
@@ -82,7 +82,7 @@ CREATE_PRNCASE_SOUND_PUT_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_
 CREATE_PRNFACT_HEARD_DEL_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_del_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context_ERASE TEXT)"""
 CREATE_PRNFACT_HEARD_DEL_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_del_raw (translate_spark_num INTEGER, spark_num INTEGER, face_name_otx TEXT, face_name_inx TEXT, person_name_otx TEXT, person_name_inx TEXT, plan_rope_otx TEXT, plan_rope_inx TEXT, fact_context_ERASE_otx TEXT, fact_context_ERASE_inx TEXT)"""
 CREATE_PRNFACT_HEARD_DEL_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_del_vld (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context_ERASE TEXT)"""
-CREATE_PRNFACT_HEARD_PUT_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_put_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context TEXT, fact_state TEXT, fact_lower_otx REAL, fact_lower_inx REAL, fact_upper_otx REAL, fact_upper_inx REAL, knot TEXT, context_plan_close TEXT, context_plan_denom TEXT, context_plan_morph TEXT, inx_epoch_diff INTEGER)"""
+CREATE_PRNFACT_HEARD_PUT_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_put_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context TEXT, fact_state TEXT, fact_lower_otx REAL, fact_lower_inx REAL, fact_upper_otx REAL, fact_upper_inx REAL, knot TEXT, context_plan_close REAL, context_plan_denom REAL, context_plan_morph REAL, inx_epoch_diff INTEGER)"""
 CREATE_PRNFACT_HEARD_PUT_RAW_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_put_raw (translate_spark_num INTEGER, spark_num INTEGER, face_name_otx TEXT, face_name_inx TEXT, person_name_otx TEXT, person_name_inx TEXT, plan_rope_otx TEXT, plan_rope_inx TEXT, fact_context_otx TEXT, fact_context_inx TEXT, fact_state_otx TEXT, fact_state_inx TEXT, fact_lower REAL, fact_upper REAL, knot TEXT)"""
 CREATE_PRNFACT_HEARD_PUT_VLD_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_h_put_vld (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context TEXT, fact_state TEXT, fact_lower REAL, fact_upper REAL, knot TEXT)"""
 CREATE_PRNFACT_SOUND_DEL_AGG_SQLSTR = """CREATE TABLE IF NOT EXISTS person_plan_factunit_s_del_agg (spark_num INTEGER, face_name TEXT, person_name TEXT, plan_rope TEXT, fact_context_ERASE TEXT, error_message TEXT)"""
@@ -430,6 +430,21 @@ def get_person_heard_vld_tablenames() -> set[str]:
 def create_sound_and_heard_tables(conn_or_cursor: sqlite3_Connection):
     for create_table_sqlstr in get_prime_create_table_sqlstrs().values():
         conn_or_cursor.execute(create_table_sqlstr)
+
+
+def create_prime_db_table(
+    cursor: sqlite3_Connection,
+    idea_dimen_or_abbv7: str,
+    stage0: str,
+    stage1: str,
+    put_del: str = None,
+) -> str:
+    """Creates table in database and returns tablename"""
+    tablename = create_prime_tablename(idea_dimen_or_abbv7, stage0, stage1, put_del)
+    prime_create_table_sqlstrs = get_prime_create_table_sqlstrs()
+    x_create_table_sqlstr = prime_create_table_sqlstrs.get(tablename)
+    cursor.execute(x_create_table_sqlstr)
+    return tablename
 
 
 def create_all_idea_tables(conn_or_cursor: sqlite3_Connection):
@@ -1117,6 +1132,8 @@ def get_update_heard_agg_timenum_sqlstrs() -> dict[str]:
 # Create "_otx" and "_inx" columns for
 # reason_lower, reason_upper, fact_lower, fact_upper, tran_time, bud_time,
 def get_update_prncase_inx_epoch_diff_sqlstr() -> str:
+    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values"""
+
     nabtime_tablename = create_prime_tablename("nabu_timenum", "h", "agg")
     prncase_abbv = "person_plan_reason_caseunit"
     prncase_tablename = create_prime_tablename(prncase_abbv, "h", "agg", "put")
@@ -1137,6 +1154,7 @@ WHERE {prncase_tablename}.spark_num IN (SELECT spark_num FROM spark_inx_epoch_di
 
 
 def get_update_prnfact_inx_epoch_diff_sqlstr() -> str:
+    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values"""
     nabtime_tablename = create_prime_tablename("nabu_timenum", "h", "agg")
     prnfact_tablename = create_prime_tablename("prnfact", "h", "agg", "put")
     return f"""
@@ -1156,26 +1174,31 @@ WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_inx_epoch_di
 
 
 def get_update_prncase_context_plan_sqlstr() -> str:
-    prncase_tablename = create_prime_tablename("prncase", "h", "agg", "put")
-    prnplan_tablename = create_prime_tablename("prnplan", "h", "agg", "put")
-    return f"""
-WITH spark_prnplan AS (
-    SELECT spark_num, close, denom, morph
-    FROM {prnplan_tablename}
-    GROUP BY spark_num, close, denom, morph
-)
-UPDATE {prncase_tablename}
+    """Returns update statement that sets prncase_h_put_agg columns from prnplan columns
+    context_plan_close = spark_prnplan.close
+    context_plan_denom = spark_prnplan.denom
+    context_plan_morph = spark_prnplan.morph
+    """
+    return """
+UPDATE person_plan_reason_caseunit_h_put_agg as prncase
 SET 
-  context_plan_close = spark_prnplan.close
-, context_plan_denom = spark_prnplan.denom
-, context_plan_morph = spark_prnplan.morph
-FROM spark_prnplan
-WHERE {prncase_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
+  context_plan_close = prnplan.close
+, context_plan_denom = prnplan.denom
+, context_plan_morph = prnplan.morph
+FROM person_planunit_h_put_agg prnplan
+WHERE prncase.spark_num = prnplan.spark_num
+    AND prncase.person_name = prnplan.person_name
+    AND prncase.reason_context = prnplan.plan_rope
 ;
 """
 
 
 def get_update_prnfact_context_plan_sqlstr() -> str:
+    """Returns update statement that sets prnfact_h_put_agg columns from prnplan columns
+    context_plan_close = spark_prnplan.close
+    context_plan_denom = spark_prnplan.denom
+    context_plan_morph = spark_prnplan.morph
+    """
     prnfact_tablename = create_prime_tablename("prnfact", "h", "agg", "put")
     prnplan_tablename = create_prime_tablename("prnplan", "h", "agg", "put")
     return f"""

--- a/src/ch18_world_etl/etl_sqlstr.py
+++ b/src/ch18_world_etl/etl_sqlstr.py
@@ -1132,7 +1132,9 @@ def get_update_heard_agg_timenum_sqlstrs() -> dict[str]:
 # Create "_otx" and "_inx" columns for
 # reason_lower, reason_upper, fact_lower, fact_upper, tran_time, bud_time,
 def get_update_prncase_inx_epoch_diff_sqlstr() -> str:
-    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values"""
+    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values
+    reference key: pchap0
+    """
 
     nabtime_tablename = create_prime_tablename("nabu_timenum", "h", "agg")
     prncase_abbv = "person_plan_reason_caseunit"
@@ -1154,7 +1156,9 @@ WHERE {prncase_tablename}.spark_num IN (SELECT spark_num FROM spark_inx_epoch_di
 
 
 def get_update_prnfact_inx_epoch_diff_sqlstr() -> str:
-    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values"""
+    """Returns update statement that sets h_put_agg.inx_epoch_diff column from nabtime values
+    reference key: pfhap0
+    """
     nabtime_tablename = create_prime_tablename("nabu_timenum", "h", "agg")
     prnfact_tablename = create_prime_tablename("prnfact", "h", "agg", "put")
     return f"""
@@ -1178,6 +1182,7 @@ def get_update_prncase_context_plan_sqlstr() -> str:
     context_plan_close = spark_prnplan.close
     context_plan_denom = spark_prnplan.denom
     context_plan_morph = spark_prnplan.morph
+    reference key: pchap1
     """
     return """
 UPDATE person_plan_reason_caseunit_h_put_agg as prncase
@@ -1199,21 +1204,16 @@ def get_update_prnfact_context_plan_sqlstr() -> str:
     context_plan_denom = spark_prnplan.denom
     context_plan_morph = spark_prnplan.morph
     """
-    prnfact_tablename = create_prime_tablename("prnfact", "h", "agg", "put")
-    prnplan_tablename = create_prime_tablename("prnplan", "h", "agg", "put")
     return f"""
-WITH spark_prnplan AS (
-    SELECT spark_num, close, denom, morph
-    FROM {prnplan_tablename}
-    GROUP BY spark_num, close, denom, morph
-)
-UPDATE {prnfact_tablename}
+UPDATE person_plan_factunit_h_put_agg as prnfact
 SET 
-  context_plan_close = spark_prnplan.close
-, context_plan_denom = spark_prnplan.denom
-, context_plan_morph = spark_prnplan.morph
-FROM spark_prnplan
-WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
+  context_plan_close = prnplan.close
+, context_plan_denom = prnplan.denom
+, context_plan_morph = prnplan.morph
+FROM person_planunit_h_put_agg prnplan
+WHERE prnfact.spark_num = prnplan.spark_num
+    AND prnfact.person_name = prnplan.person_name
+    AND prnfact.fact_context = prnplan.plan_rope
 ;
 """
 

--- a/src/ch18_world_etl/obj2db_person.py
+++ b/src/ch18_world_etl/obj2db_person.py
@@ -1227,6 +1227,7 @@ def insert_h_agg_obj(
     spark_num: SparkInt,
     face_name: FaceName,
 ):
+    """Given database cursor and PersonUnit obj insert obj attributes into h_agg tables"""
     job_person.conpute()
     x_objkeysholder = ObjKeysHolder(
         spark_num=spark_num,

--- a/src/ch18_world_etl/test/_util/ch18_examples.py
+++ b/src/ch18_world_etl/test/_util/ch18_examples.py
@@ -197,6 +197,7 @@ WHERE {kw.spark_num} = {x_spark_num}
     AND {kw.reason_state} = '{x_reason_state}'
 ;
 """
+    print(select_sqlstr)
     cursor.execute(select_sqlstr)
     prncase_heard_aggs = []
     for row in cursor.fetchall():

--- a/src/ch18_world_etl/test/etl_sqlstrs/test__csv_from_db.py
+++ b/src/ch18_world_etl/test/etl_sqlstrs/test__csv_from_db.py
@@ -268,8 +268,8 @@ def test_save_to_split_csvs_CreatesFiles_Scenario4_knot_is_NULL(
     temp_dir_setup, cursor0: Cursor
 ):
     # ESTABLISH
-    # TODO get rid of knot is NULL option. It's a temporary solution that assumes the knot is a
-    # single character length
+    # TODO get rid of knot is NULL option. It's a temporary solution that assumes the knot is a single character length
+    # means the knot column in the tables need to be populated not by knot column of original inputs but by calculated knot for each moment
     x_tablename = "test_table568"
     key_columns = ["hair", "user"]
     create_sql = f"""CREATE TABLE {x_tablename} (hair INTEGER,user TEXT,y_int INTEGER, run TEXT, {kw.knot} TEXT);"""

--- a/src/ch18_world_etl/test/etl_sqlstrs/test__csv_from_db.py
+++ b/src/ch18_world_etl/test/etl_sqlstrs/test__csv_from_db.py
@@ -264,57 +264,55 @@ def test_save_to_split_csvs_CreatesFiles_Scenario3_Different_Knots(
     assert x_csv[2] == expected_csv2_row
 
 
-def test_save_to_split_csvs_CreatesFiles_Scenario4_knot_is_NULL(
-    temp_dir_setup, cursor0: Cursor
-):
-    # ESTABLISH
-    # TODO get rid of knot is NULL option. It's a temporary solution that assumes the knot is a single character length
-    # means the knot column in the tables need to be populated not by knot column of original inputs but by calculated knot for each moment
-    x_tablename = "test_table568"
-    key_columns = ["hair", "user"]
-    create_sql = f"""CREATE TABLE {x_tablename} (hair INTEGER,user TEXT,y_int INTEGER, run TEXT, {kw.knot} TEXT);"""
-    cursor0.execute(create_sql)
-    x_blue = f";{exx.blue};"
-    x_red = f"/{exx.red}/"
-    insert1_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_blue}", "A", 200, "yes", NULL);"""
-    insert2_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_blue}", "A", 333, "yes", NULL);"""
-    insert3_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_red}", "B", 200, "yes", NULL);"""
-    cursor0.execute(insert1_sql)
-    cursor0.execute(insert2_sql)
-    cursor0.execute(insert3_sql)
-    x_dir = get_temp_dir()
-    hairs_str = "hairs"
-    y_ints_str = "y_ints"
-    red_dir = create_path(x_dir, exx.red)
-    hairs_dir = create_path(red_dir, hairs_str)
-    red_A_dir = create_path(hairs_dir, "B")
-    red_y_ints_dir = create_path(red_A_dir, y_ints_str)
-    red_A_csv_path = create_path(red_y_ints_dir, f"{x_tablename}.csv")
-    print(f"{red_A_csv_path=}")
-    assert os_path_exists(red_A_csv_path) is False
+# def test_save_to_split_csvs_CreatesFiles_Scenario4_knot_is_NULL(
+#     temp_dir_setup, cursor0: Cursor
+# ):
+#     # ESTABLISH
+#     x_tablename = "test_table568"
+#     key_columns = ["hair", "user"]
+#     create_sql = f"""CREATE TABLE {x_tablename} (hair INTEGER,user TEXT,y_int INTEGER, run TEXT, {kw.knot} TEXT);"""
+#     cursor0.execute(create_sql)
+#     x_blue = f";{exx.blue};"
+#     x_red = f"/{exx.red}/"
+#     insert1_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_blue}", "A", 200, "yes", NULL);"""
+#     insert2_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_blue}", "A", 333, "yes", NULL);"""
+#     insert3_sql = f"""INSERT INTO {x_tablename} (hair, user, y_int, run, {kw.knot}) VALUES ("{x_red}", "B", 200, "yes", NULL);"""
+#     cursor0.execute(insert1_sql)
+#     cursor0.execute(insert2_sql)
+#     cursor0.execute(insert3_sql)
+#     x_dir = get_temp_dir()
+#     hairs_str = "hairs"
+#     y_ints_str = "y_ints"
+#     red_dir = create_path(x_dir, exx.red)
+#     hairs_dir = create_path(red_dir, hairs_str)
+#     red_A_dir = create_path(hairs_dir, "B")
+#     red_y_ints_dir = create_path(red_A_dir, y_ints_str)
+#     red_A_csv_path = create_path(red_y_ints_dir, f"{x_tablename}.csv")
+#     print(f"{red_A_csv_path=}")
+#     assert os_path_exists(red_A_csv_path) is False
 
-    # WHEN
-    save_to_split_csvs(
-        conn_or_cursor=cursor0,
-        tablename=x_tablename,
-        key_columns=key_columns,
-        dst_dir=x_dir,
-        col1_prefix=hairs_str,
-        col2_prefix=y_ints_str,
-    )
+#     # WHEN
+#     save_to_split_csvs(
+#         conn_or_cursor=cursor0,
+#         tablename=x_tablename,
+#         key_columns=key_columns,
+#         dst_dir=x_dir,
+#         col1_prefix=hairs_str,
+#         col2_prefix=y_ints_str,
+#     )
 
-    # THEN
-    assert os_path_exists(red_A_csv_path)
-    expected_A1_row = (x_red, "B", 200, "yes", "")
-    x_column_types = {
-        "hair": "TEXT",
-        "user": "TEXT",
-        "y_int": "INTEGER",
-        "run": "TEXT",
-        kw.knot: "TEXT",
-    }
-    A1_csv = open_csv_with_types(red_A_csv_path, x_column_types)
-    print(f"{A1_csv[0]=}")
-    print(f"{A1_csv[1]=}")
-    assert A1_csv[0] == ("hair", "user", "y_int", "run", kw.knot)
-    assert A1_csv[1] == expected_A1_row
+#     # THEN
+#     assert os_path_exists(red_A_csv_path)
+#     expected_A1_row = (x_red, "B", 200, "yes", "")
+#     x_column_types = {
+#         "hair": "TEXT",
+#         "user": "TEXT",
+#         "y_int": "INTEGER",
+#         "run": "TEXT",
+#         kw.knot: "TEXT",
+#     }
+#     A1_csv = open_csv_with_types(red_A_csv_path, x_column_types)
+#     print(f"{A1_csv[0]=}")
+#     print(f"{A1_csv[1]=}")
+#     assert A1_csv[0] == ("hair", "user", "y_int", "run", kw.knot)
+#     assert A1_csv[1] == expected_A1_row

--- a/src/ch18_world_etl/test/etl_sqlstrs/test__etl_table.py
+++ b/src/ch18_world_etl/test/etl_sqlstrs/test__etl_table.py
@@ -2,6 +2,7 @@ from os import getcwd as os_getcwd
 from src.ch00_py.file_toolbox import create_path
 from src.ch17_idea.idea_config import get_idea_config_dict
 from src.ch18_world_etl.etl_config import (
+    ALL_DIMEN_ABBV2,
     ALL_DIMEN_ABBV7,
     create_prime_table_sqlstr,
     create_prime_tablename,
@@ -9,6 +10,8 @@ from src.ch18_world_etl.etl_config import (
     etl_idea_category_config_path,
     get_all_dimen_columns_set,
     get_del_dimen_columns_set,
+    get_dimen_abbv2,
+    get_dimen_abbv7,
     get_etl_category_stages_dict,
     get_prime_columns,
     remove_inx_columns,
@@ -40,10 +43,37 @@ def test_remove_staging_columns_ReturnsObj():
 
 
 def test_ALL_DIMEN_ABBV7_has_all_dimens():
+    # ESTABLISH
+    idea_config_keys = set(get_idea_config_dict().keys())
+    idea_config_keys.add("translate_core")
+
+    # WHEN / THEN
+    assert len(ALL_DIMEN_ABBV7) == len(idea_config_keys)
+
+
+def test_get_dimen_abbv7_HasAll_dimens():
     # ESTABLISH / WHEN / THEN
-    assert len(ALL_DIMEN_ABBV7) == len(get_idea_config_dict())
-    x_set = {len(dimen) for dimen in ALL_DIMEN_ABBV7}
-    assert x_set == {7}
+    for idea_dimen in get_idea_config_dict().keys():
+        assert get_dimen_abbv7(idea_dimen) in ALL_DIMEN_ABBV7
+
+
+def test_get_dimen_abbv2_HasAll_dimens():
+    # ESTABLISH / WHEN
+    gen_abbv2_set = ALL_DIMEN_ABBV2
+
+    # THEN
+    expected_abbv2_set = set()
+    idea_config_keys = set(get_idea_config_dict().keys())
+    idea_config_keys.add("translate_core")
+    for idea_dimen in idea_config_keys:
+        abbv2 = get_dimen_abbv2(idea_dimen)
+        print(f"{abbv2=}")
+        assert abbv2
+        expected_abbv2_set.add(abbv2)
+        assert abbv2 in gen_abbv2_set
+
+    assert gen_abbv2_set == expected_abbv2_set
+    assert len(gen_abbv2_set) == len(ALL_DIMEN_ABBV7)
 
 
 def test_create_prime_tablename_ReturnsObj_Scenario0_ExpectedReturns():

--- a/src/ch18_world_etl/test/etl_sqlstrs/test_etl_sqlstrs_prime.py
+++ b/src/ch18_world_etl/test/etl_sqlstrs/test_etl_sqlstrs_prime.py
@@ -27,6 +27,7 @@ from src.ch18_world_etl.etl_sqlstr import (
     create_insert_missing_face_name_into_translate_core_vld_sqlstr,
     create_insert_translate_core_agg_into_vld_sqlstr,
     create_insert_translate_sound_vld_table_sqlstr,
+    create_prime_db_table,
     create_prime_tablename as prime_tbl,
     create_sound_agg_insert_sqlstrs,
     create_sound_and_heard_tables,
@@ -94,7 +95,7 @@ def test_get_prime_create_table_sqlstrs_ReturnsObj():
         if gen_sqlstr != expected_sqlstr:
             print(f"{expected_sql_ref=}")
             print(expected_sqlstr)
-        print(f"{expected_sql_ref=}")
+        # print(f"{expected_sql_ref=}")
         assert gen_sqlstr == expected_sqlstr
     assert create_table_sqlstrs == expected_sqlstrs_dict
 
@@ -220,20 +221,20 @@ def test_create_sound_and_heard_tables_CreatesMomentRawTables(cursor0: Cursor):
     vld_str = "vld"
     put_str = "put"
     del_str = "del"
-    prnunit_s_put_agg_table = prime_tbl("personunit", "s", agg_str, put_str)
-    prnptnr_s_put_agg_table = prime_tbl("prnptnr", "s", agg_str, put_str)
-    prnmemb_s_put_agg_table = prime_tbl("prnmemb", "s", agg_str, put_str)
-    prnfact_s_del_agg_table = prime_tbl("prnfact", "s", agg_str, del_str)
-    prnfact_s_del_vld_table = prime_tbl("prnfact", "s", vld_str, del_str)
+    prnunit_s_put_agg_table = prime_tbl(kw.personunit, "s", agg_str, put_str)
+    prnptnr_s_put_agg_table = prime_tbl(kw.prnptnr, "s", agg_str, put_str)
+    prnmemb_s_put_agg_table = prime_tbl(kw.prnmemb, "s", agg_str, put_str)
+    prnfact_s_del_agg_table = prime_tbl(kw.prnfact, "s", agg_str, del_str)
+    prnfact_s_del_vld_table = prime_tbl(kw.prnfact, "s", vld_str, del_str)
     momentunit_s_agg_table = prime_tbl(kw.momentunit, "s", agg_str)
     momentunit_s_vld_table = prime_tbl(kw.momentunit, "s", vld_str)
-    trltitl_s_agg_table = prime_tbl("trltitl", "s", agg_str)
-    mmthour_h_vld_table = prime_tbl("mmthour", "h", vld_str)
-    nabtime_s_raw_table = prime_tbl("nabtime", "s", raw_str)
-    trltitl_s_raw_table = prime_tbl("trltitl", "s", raw_str)
-    trlcore_s_raw_table = prime_tbl("trlcore", "s", raw_str)
-    trlcore_s_agg_table = prime_tbl("trlcore", "s", agg_str)
-    trlcore_s_vld_table = prime_tbl("trlcore", "s", vld_str)
+    trltitl_s_agg_table = prime_tbl(kw.trltitl, "s", agg_str)
+    mmthour_h_vld_table = prime_tbl(kw.mmthour, "h", vld_str)
+    nabtime_s_raw_table = prime_tbl(kw.nabtime, "s", raw_str)
+    trltitl_s_raw_table = prime_tbl(kw.trltitl, "s", raw_str)
+    trlcore_s_raw_table = prime_tbl(kw.trlcore, "s", raw_str)
+    trlcore_s_agg_table = prime_tbl(kw.trlcore, "s", agg_str)
+    trlcore_s_vld_table = prime_tbl(kw.trlcore, "s", vld_str)
 
     assert not db_table_exists(cursor0, prnunit_s_put_agg_table)
     assert not db_table_exists(cursor0, prnptnr_s_put_agg_table)
@@ -275,6 +276,25 @@ def test_create_sound_and_heard_tables_CreatesMomentRawTables(cursor0: Cursor):
     assert db_table_exists(cursor0, trlcore_s_agg_table)
     assert db_table_exists(cursor0, trlcore_s_vld_table)
     assert len(get_db_tables(cursor0)) == 182
+
+
+def test_create_prime_db_table_CreatesSingleTable(cursor0: Cursor):
+    # ESTABLISH
+    assert len(get_db_tables(cursor0)) == 0
+    agg_str = "agg"
+    put_str = "put"
+    prnunit_s_put_agg_table = prime_tbl(kw.personunit, "s", agg_str, put_str)
+
+    assert not db_table_exists(cursor0, prnunit_s_put_agg_table)
+    assert len(get_db_tables(cursor0)) == 0
+
+    # WHEN
+    gen_tablename = create_prime_db_table(cursor0, kw.personunit, "s", agg_str, put_str)
+
+    # THEN
+    assert db_table_exists(cursor0, prnunit_s_put_agg_table)
+    assert len(get_db_tables(cursor0)) == 1
+    assert gen_tablename == prnunit_s_put_agg_table
 
 
 def test_create_sound_raw_update_inconsist_error_message_sqlstr_ReturnsObj_Scenario0_TranslateDimen(

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum__sqlstrs.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum__sqlstrs.py
@@ -13,16 +13,11 @@ from src.ch18_world_etl.etl_sqlstr import (
 )
 from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
 
-# TODO create function that updates all nabuable otx fields.
-# identify the change
-# update semantic_type: ReasonNum person_plan_reason_caseunit_h_agg_put reason_lower, reason_upper
-# update semantic_type: ReasonNum person_plan_factunit_h_agg_put fact_lower, fact_upper
-
 
 def test_get_update_prncase_inx_epoch_diff_sqlstr_ReturnsObj():
     # ESTABLISH
     prncase_tablename = prime_tbl(kw.prncase, "h", "agg", "put")
-    nabtime_tablename = prime_tbl(kw.nabu_timenum, "h", "agg")
+    nabtime_tablename = prime_tbl(kw.nabtime, "h", "agg")
 
     # WHEN
     update_sqlstr = get_update_prncase_inx_epoch_diff_sqlstr()
@@ -75,33 +70,34 @@ WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_inx_epoch_di
     assert update_sqlstr == expected_update_sqlstr
 
 
-def test_get_update_prncase_context_plan_sqlstr_ReturnsObj():
-    # ESTABLISH
-    prncase_tablename = prime_tbl(kw.person_plan_reason_caseunit, "h", "agg", "put")
-    prnplan_tablename = prime_tbl(kw.person_planunit, "h", "agg", "put")
+# def test_get_update_prncase_context_plan_sqlstr_ReturnsObj():
+# TODO reactivate
+#     # ESTABLISH
+#     prncase_tablename = prime_tbl(kw.person_plan_reason_caseunit, "h", "agg", "put")
+#     prnplan_tablename = prime_tbl(kw.person_planunit, "h", "agg", "put")
 
-    # WHEN
-    update_sqlstr = get_update_prncase_context_plan_sqlstr()
+#     # WHEN
+#     update_sqlstr = get_update_prncase_context_plan_sqlstr()
 
-    # THEN
-    assert update_sqlstr
-    expected_update_sqlstr = f"""
-WITH spark_prnplan AS (
-    SELECT {kw.spark_num}, {kw.close}, {kw.denom}, {kw.morph}
-    FROM {prnplan_tablename}
-    GROUP BY {kw.spark_num}, {kw.close}, {kw.denom}, {kw.morph}
-)
-UPDATE {prncase_tablename}
-SET 
-  context_plan_close = spark_prnplan.{kw.close}
-, context_plan_denom = spark_prnplan.{kw.denom}
-, context_plan_morph = spark_prnplan.{kw.morph}
-FROM spark_prnplan
-WHERE {prncase_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
-;
-"""
-    print(expected_update_sqlstr)
-    assert update_sqlstr == expected_update_sqlstr
+#     # THEN
+#     assert update_sqlstr
+#     expected_update_sqlstr = f"""
+# WITH spark_prnplan AS (
+#     SELECT {kw.spark_num}, {kw.close}, {kw.denom}, {kw.morph}
+#     FROM {prnplan_tablename}
+#     GROUP BY {kw.spark_num}, {kw.close}, {kw.denom}, {kw.morph}
+# )
+# UPDATE {prncase_tablename}
+# SET
+#   context_plan_close = spark_prnplan.{kw.close}
+# , context_plan_denom = spark_prnplan.{kw.denom}
+# , context_plan_morph = spark_prnplan.{kw.morph}
+# FROM spark_prnplan
+# WHERE {prncase_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
+# ;
+# """
+#     print(expected_update_sqlstr)
+#     assert update_sqlstr == expected_update_sqlstr
 
 
 def test_get_update_prnfact_context_plan_sqlstr_ReturnsObj():
@@ -191,3 +187,9 @@ WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_prnfact)
 """
     print(expected_update_sqlstr)
     assert update_sqlstr == expected_update_sqlstr
+
+
+# TODO create function that updates all nabuable otx fields.
+# identify the change
+# update semantic_type: ReasonNum person_plan_reason_caseunit_h_agg_put reason_lower, reason_upper
+# update semantic_type: ReasonNum person_plan_factunit_h_agg_put fact_lower, fact_upper

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum__sqlstrs.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum__sqlstrs.py
@@ -99,34 +99,34 @@ WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_inx_epoch_di
 #     print(expected_update_sqlstr)
 #     assert update_sqlstr == expected_update_sqlstr
 
+# TODO reactivate test
+# def test_get_update_prnfact_context_plan_sqlstr_ReturnsObj():
+#     # ESTABLISH
+#     prnfact_tablename = prime_tbl(kw.prnfact, "h", "agg", "put")
+#     prnplan_tablename = prime_tbl(kw.person_planunit, "h", "agg", "put")
 
-def test_get_update_prnfact_context_plan_sqlstr_ReturnsObj():
-    # ESTABLISH
-    prnfact_tablename = prime_tbl(kw.prnfact, "h", "agg", "put")
-    prnplan_tablename = prime_tbl(kw.person_planunit, "h", "agg", "put")
+#     # WHEN
+#     update_sqlstr = get_update_prnfact_context_plan_sqlstr()
 
-    # WHEN
-    update_sqlstr = get_update_prnfact_context_plan_sqlstr()
-
-    # THEN
-    assert update_sqlstr
-    expected_update_sqlstr = f"""
-WITH spark_prnplan AS (
-    SELECT spark_num, close, denom, morph
-    FROM {prnplan_tablename}
-    GROUP BY spark_num, close, denom, morph
-)
-UPDATE {prnfact_tablename}
-SET 
-  context_plan_close = spark_prnplan.close
-, context_plan_denom = spark_prnplan.denom
-, context_plan_morph = spark_prnplan.morph
-FROM spark_prnplan
-WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
-;
-"""
-    print(expected_update_sqlstr)
-    assert update_sqlstr == expected_update_sqlstr
+#     # THEN
+#     assert update_sqlstr
+#     expected_update_sqlstr = f"""
+# WITH spark_prnplan AS (
+#     SELECT spark_num, close, denom, morph
+#     FROM {prnplan_tablename}
+#     GROUP BY spark_num, close, denom, morph
+# )
+# UPDATE {prnfact_tablename}
+# SET
+#   context_plan_close = spark_prnplan.close
+# , context_plan_denom = spark_prnplan.denom
+# , context_plan_morph = spark_prnplan.morph
+# FROM spark_prnplan
+# WHERE {prnfact_tablename}.spark_num IN (SELECT spark_num FROM spark_prnplan)
+# ;
+# """
+#     print(expected_update_sqlstr)
+#     assert update_sqlstr == expected_update_sqlstr
 
 
 def test_get_update_prncase_range_sqlstr_ReturnsObj():

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_columns.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_columns.py
@@ -57,7 +57,7 @@ from src.ch18_world_etl.test._util.ch18_examples import (
     insert_prncase_special_h_agg as insert_prncase,
     insert_prnfact_special_h_agg as insert_prnfact,
     select_mmtoffi_special_offi_time_inx as select_offi_time_inx,
-    select_prncase_special_h_agg as select_prncase,
+    select_prncase_special_h_agg as pchap1_select_prncase,
     select_prnfact_special_h_agg as select_prnfact,
 )
 from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
@@ -75,218 +75,6 @@ from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
 # 3. create update queries to set the nabuable fields using inx_epoch_diff column
 # 4. create test for function that both updates inx_epoch_diff and nabuable fields
 # 5. create a heard_agg test that confirms heard_vld pulls from nabuable_inx fields (probably not case now)
-
-
-# update semantic_type: ReasonNum person_plan_reason_caseunit_h_agg_put inx_epoch_diff
-def test_get_update_prncase_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7 = 7
-    bob_person = get_bob_five_with_mop_dayly()
-    create_sound_and_heard_tables(cursor0)
-    h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
-    otx_time = 199
-    inx_time = 13
-    moment_rope = bob_person.planroot.get_plan_rope()
-    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
-    insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
-    print(f"{h_agg_table=}")
-    sel_prncase_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
-    assert get_row_count(cursor0, h_agg_table) == 1
-    assert cursor0.execute(sel_prncase_str).fetchone()[0] is None
-
-    # WHEN
-    cursor0.execute(get_update_prncase_inx_epoch_diff_sqlstr())
-
-    # THEN
-    assert get_row_count(cursor0, h_agg_table) == 1
-    after_inx_epoch_diff = cursor0.execute(sel_prncase_str).fetchone()[0]
-    assert after_inx_epoch_diff
-    assert after_inx_epoch_diff == otx_time - inx_time
-    assert after_inx_epoch_diff == 186
-
-
-def test_get_update_prnfact_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7 = 7
-    bob_person = get_bob_five_with_mop_dayly()
-    bob_person.add_fact(wx.time_rope, wx.time_rope, 0, 100)
-    create_sound_and_heard_tables(cursor0)
-    h_agg_table = create_prime_tablename(kw.prnfact, "h", "agg", "put")
-    otx_time = 199
-    inx_time = 13
-    moment_rope = bob_person.planroot.get_plan_rope()
-    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
-    insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
-    # TODO create SQL query that selects only the fields of interest (ok that it cannot be reused in other tests)
-    print(f"{h_agg_table=}")
-    sel_prnfact_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
-    assert get_row_count(cursor0, h_agg_table) == 1
-    assert cursor0.execute(sel_prnfact_str).fetchone()[0] is None
-
-    # WHEN
-    cursor0.execute(get_update_prnfact_inx_epoch_diff_sqlstr())
-
-    # THEN
-    assert get_row_count(cursor0, h_agg_table) == 1
-    after_inx_epoch_diff = cursor0.execute(sel_prnfact_str).fetchone()[0]
-    assert after_inx_epoch_diff
-    assert after_inx_epoch_diff == otx_time - inx_time
-    assert after_inx_epoch_diff == 186
-
-
-def insert_into_prncase(cursor0: Cursor, x_values: list[list]) -> str:
-    """x_cols = [kw.spark_num, kw.person_name, kw.reason_context]"""
-    x_cols = [kw.spark_num, kw.person_name, kw.reason_context]
-    tablename = create_prime_db_table(cursor0, kw.prncase, "h", "agg", "put")
-    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
-    cursor0.execute(insert_sql)
-    return insert_sql
-
-
-def insert_into_prnplan(cursor0: Cursor, x_values: list[list]) -> str:
-    """x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]"""
-    x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]
-    tablename = create_prime_db_table(cursor0, kw.prnplan, "h", "agg", "put")
-    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
-    cursor0.execute(insert_sql)
-    return insert_sql
-
-
-def select_prncase(cursor0: Cursor, print_rows: bool = False) -> list[tuple]:
-    """SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph"""
-    prncase_h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
-    sel_prncase_str = f"""
-SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph 
-FROM {prncase_h_agg_table}
-ORDER BY spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph
-;"""
-    x_rows = cursor0.execute(sel_prncase_str).fetchall()
-    if print_rows:
-        print(x_rows)
-    return x_rows
-
-
-def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario0_1row(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7 = 7
-    prncase_vals = [[spark7, exx.sue, wx.clean_rope]]
-    x0_close, x0_denom, x0_morph = (44, 55, 66)
-    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
-    prnplan_in_vals = [[spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph]]
-    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
-    assert select_prncase(cursor0, True) == [
-        (spark7, exx.sue, wx.clean_rope, None, None, None)
-    ]
-
-    # WHEN
-    cursor0.execute(get_update_prncase_context_plan_sqlstr())
-
-    # THEN
-    assert select_prncase(cursor0) == [
-        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph)
-    ]
-
-
-def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario1_2rows(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7, spark9 = (7, 9)
-    x0_close, x0_denom, x0_morph = (44, 55, 66)
-    x1_close, x1_denom, x1_morph = (77, 88, 99)
-    prnplan_in_vals = [
-        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
-        [spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph],
-    ]
-    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
-    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark9, exx.sue, wx.clean_rope]]
-    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
-
-    # BEFORE
-    assert select_prncase(cursor0) == [
-        (spark7, exx.sue, wx.clean_rope, None, None, None),
-        (spark9, exx.sue, wx.clean_rope, None, None, None),
-    ]
-
-    # WHEN
-    update_sql = get_update_prncase_context_plan_sqlstr()
-    cursor0.execute(update_sql)
-
-    # THEN
-    assert select_prncase(cursor0, True) == [
-        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
-        (spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph),
-    ]
-
-
-def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario3_DifferentPersons(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7 = 7
-    x0_close, x0_denom, x0_morph = (44, 55, 66)
-    x1_close, x1_denom, x1_morph = (77, 88, 99)
-    prnplan_in_vals = [
-        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
-        [spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph],
-    ]
-    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
-    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.zia, wx.clean_rope]]
-    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
-
-    # BEFORE
-    assert select_prncase(cursor0) == [
-        (spark7, exx.sue, wx.clean_rope, None, None, None),
-        (spark7, exx.zia, wx.clean_rope, None, None, None),
-    ]
-
-    # WHEN
-    update_sql = get_update_prncase_context_plan_sqlstr()
-    cursor0.execute(update_sql)
-
-    # THEN
-    assert select_prncase(cursor0, True) == [
-        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
-        (spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph),
-    ]
-
-
-def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario4_Different_plan_rope(
-    cursor0: Cursor,
-):
-    # ESTABLISH
-    spark7 = 7
-    x0_close, x0_denom, x0_morph = (44, 55, 66)
-    x1_close, x1_denom, x1_morph = (77, 88, 99)
-    prnplan_in_vals = [
-        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
-        [spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph],
-    ]
-    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
-    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.sue, wx.mop_rope]]
-    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
-
-    # BEFORE
-    assert select_prncase(cursor0) == [
-        (spark7, exx.sue, wx.clean_rope, None, None, None),
-        (spark7, exx.sue, wx.mop_rope, None, None, None),
-    ]
-
-    # WHEN
-    update_sql = get_update_prncase_context_plan_sqlstr()
-    cursor0.execute(update_sql)
-
-    # THEN
-    assert select_prncase(cursor0, True) == [
-        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
-        (spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph),
-    ]
 
 
 # identify the change
@@ -351,7 +139,7 @@ def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario4_Different
 #         inx_time = 0
 #         insert_otx_inx_time(cursor, spark7, exx.yao, m_label, otx_time, inx_time)
 #         insert_h_agg_obj(cursor, bob_person, spark7, exx.yao)
-#         prncase_objs = select_prncase(
+#         prncase_objs = pchap1_select_prncase(
 #             cursor, spark7, "YY", exx.bob, wx.mop_rope, wx.day_rope, wx.day_rope
 #         )
 #         print(f"{prncase_objs=}")
@@ -368,7 +156,7 @@ def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario4_Different
 #         add_frame_to_db_caseunit(cursor, day_plan.close, day_plan.denom, day_plan.morph)
 
 #         # THEN
-#         after_prncase_obj0 = select_prncase(
+#         after_prncase_obj0 = pchap1_select_prncase(
 #             cursor, spark7, "YY", exx.bob, wx.mop_rope, wx.day_rope, wx.day_rope
 #         )[0]
 #         expected_lower_inx = prncase_obj0.reason_lower_otx + otx_time - inx_time

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_columns.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_columns.py
@@ -1,4 +1,9 @@
 from sqlite3 import Cursor
+from src.ch00_py.db_toolbox import (
+    create_type_reference_insert_sqlstr,
+    get_row_count,
+    get_table_columns,
+)
 from src.ch06_plan.test._util.ch06_examples import get_range_attrs
 from src.ch07_person_logic.person_tool import (
     PersonUnit,
@@ -22,6 +27,7 @@ from src.ch13_time.test._util.ch13_examples import (
 )
 from src.ch15_nabu.nabu_config import get_nabu_config_dict
 from src.ch17_idea.idea_config import get_dimens_with_idea_element
+from src.ch18_world_etl.etl_config import create_prime_tablename
 from src.ch18_world_etl.etl_nabu import (
     add_epoch_frame_to_db_personunit,
     add_frame_to_db_caseunit,
@@ -30,11 +36,14 @@ from src.ch18_world_etl.etl_nabu import (
     add_frame_to_db_reasonunit,
 )
 from src.ch18_world_etl.etl_sqlstr import (
+    create_prime_db_table,
     create_prime_tablename as prime_tbl,
     create_sound_and_heard_tables,
     get_update_heard_agg_timenum_sqlstr,
     get_update_heard_agg_timenum_sqlstrs,
+    get_update_prncase_context_plan_sqlstr,
     get_update_prncase_inx_epoch_diff_sqlstr,
+    get_update_prnfact_context_plan_sqlstr,
     get_update_prnfact_inx_epoch_diff_sqlstr,
     update_heard_agg_timenum_columns,
 )
@@ -53,9 +62,14 @@ from src.ch18_world_etl.test._util.ch18_examples import (
 )
 from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
 
-# TODO create function that updates all nabuable otx fields.
+# TODO TODO create function that updates all nabuable otx fields.
 # restart a little bit
 # 0. identify all fields that are nabuable
+#   "reason_lower", "reason_upper"
+#   "fact_lower", "fact_upper"
+#   "bud_time"
+#   "offi_time"
+#   "tran_time"
 # 1. on each of their h_agg tables make sure there is inx_epoch_diff
 # 2. create update queries to set inx_epoch_diff for all of them
 # 3. create update queries to set the nabuable fields using inx_epoch_diff column
@@ -64,34 +78,215 @@ from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
 
 
 # update semantic_type: ReasonNum person_plan_reason_caseunit_h_agg_put inx_epoch_diff
-def test_get_update_prncase_inx_epoch_diff_sqlstr_SetsColumnValues(cursor0: Cursor):
+def test_get_update_prncase_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
+    cursor0: Cursor,
+):
     # ESTABLISH
     spark7 = 7
     bob_person = get_bob_five_with_mop_dayly()
     create_sound_and_heard_tables(cursor0)
+    h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
     otx_time = 199
     inx_time = 13
-    m_label = bob_person.planroot.get_plan_rope()
-    insert_otx_inx_time(cursor0, spark7, exx.yao, m_label, otx_time, inx_time)
+    moment_rope = bob_person.planroot.get_plan_rope()
+    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
     insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
-    # TODO create SQL query that selects only the fields of interest (ok that it cannot be reused in other tests)
-    prncase_old_objs = select_prncase(
-        cursor0, spark7, exx.bob, wx.mop_rope, wx.day_rope, wx.day_rope
-    )
-    prncase_old_obj0 = prncase_old_objs[0]
-    assert prncase_old_obj0.inx_epoch_diff is None
+    print(f"{h_agg_table=}")
+    sel_prncase_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
+    assert get_row_count(cursor0, h_agg_table) == 1
+    assert cursor0.execute(sel_prncase_str).fetchone()[0] is None
 
     # WHEN
-    update_sql = get_update_prncase_inx_epoch_diff_sqlstr()
+    cursor0.execute(get_update_prncase_inx_epoch_diff_sqlstr())
+
+    # THEN
+    assert get_row_count(cursor0, h_agg_table) == 1
+    after_inx_epoch_diff = cursor0.execute(sel_prncase_str).fetchone()[0]
+    assert after_inx_epoch_diff
+    assert after_inx_epoch_diff == otx_time - inx_time
+    assert after_inx_epoch_diff == 186
+
+
+def test_get_update_prnfact_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    bob_person = get_bob_five_with_mop_dayly()
+    bob_person.add_fact(wx.time_rope, wx.time_rope, 0, 100)
+    create_sound_and_heard_tables(cursor0)
+    h_agg_table = create_prime_tablename(kw.prnfact, "h", "agg", "put")
+    otx_time = 199
+    inx_time = 13
+    moment_rope = bob_person.planroot.get_plan_rope()
+    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
+    insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
+    # TODO create SQL query that selects only the fields of interest (ok that it cannot be reused in other tests)
+    print(f"{h_agg_table=}")
+    sel_prnfact_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
+    assert get_row_count(cursor0, h_agg_table) == 1
+    assert cursor0.execute(sel_prnfact_str).fetchone()[0] is None
+
+    # WHEN
+    cursor0.execute(get_update_prnfact_inx_epoch_diff_sqlstr())
+
+    # THEN
+    assert get_row_count(cursor0, h_agg_table) == 1
+    after_inx_epoch_diff = cursor0.execute(sel_prnfact_str).fetchone()[0]
+    assert after_inx_epoch_diff
+    assert after_inx_epoch_diff == otx_time - inx_time
+    assert after_inx_epoch_diff == 186
+
+
+def insert_into_prncase(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.reason_context]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.reason_context]
+    tablename = create_prime_db_table(cursor0, kw.prncase, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def insert_into_prnplan(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]
+    tablename = create_prime_db_table(cursor0, kw.prnplan, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def select_prncase(cursor0: Cursor, print_rows: bool = False) -> list[tuple]:
+    """SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph"""
+    prncase_h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
+    sel_prncase_str = f"""
+SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph 
+FROM {prncase_h_agg_table}
+ORDER BY spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph
+;"""
+    x_rows = cursor0.execute(sel_prncase_str).fetchall()
+    if print_rows:
+        print(x_rows)
+    return x_rows
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario0_1row(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope]]
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
+    prnplan_in_vals = [[spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph]]
+    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
+    assert select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None)
+    ]
+
+    # WHEN
+    cursor0.execute(get_update_prncase_context_plan_sqlstr())
+
+    # THEN
+    assert select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph)
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario1_2rows(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7, spark9 = (7, 9)
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark9, exx.sue, wx.clean_rope]]
+    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark9, exx.sue, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
     cursor0.execute(update_sql)
 
     # THEN
-    prncase_new_objs = select_prncase(
-        cursor0, spark7, exx.bob, wx.mop_rope, wx.day_rope, wx.day_rope
-    )
-    prncase_new_obj0 = prncase_new_objs[0]
-    assert prncase_new_obj0.inx_epoch_diff == otx_time - inx_time
-    assert prncase_new_obj0.inx_epoch_diff == 186
+    assert select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario3_DifferentPersons(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.zia, wx.clean_rope]]
+    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.zia, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario4_Different_plan_rope(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = insert_into_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.sue, wx.mop_rope]]
+    prncase_insert_sql = insert_into_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.sue, wx.mop_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph),
+    ]
 
 
 # identify the change

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pchap0.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pchap0.py
@@ -1,0 +1,45 @@
+from sqlite3 import Cursor
+from src.ch00_py.db_toolbox import get_row_count
+from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
+from src.ch18_world_etl.etl_config import create_prime_tablename
+from src.ch18_world_etl.etl_sqlstr import (
+    create_sound_and_heard_tables,
+    get_update_prncase_inx_epoch_diff_sqlstr,
+)
+from src.ch18_world_etl.obj2db_person import insert_h_agg_obj
+from src.ch18_world_etl.test._util.ch18_env import cursor0
+from src.ch18_world_etl.test._util.ch18_examples import (
+    get_bob_five_with_mop_dayly,
+    insert_nabtime_h_agg_otx_inx_time as insert_otx_inx_time,
+)
+from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
+
+
+# update semantic_type: ReasonNum person_plan_reason_caseunit_h_agg_put inx_epoch_diff
+def test_get_update_prncase_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    bob_person = get_bob_five_with_mop_dayly()
+    create_sound_and_heard_tables(cursor0)
+    h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
+    otx_time = 199
+    inx_time = 13
+    moment_rope = bob_person.planroot.get_plan_rope()
+    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
+    insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
+    print(f"{h_agg_table=}")
+    sel_prncase_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
+    assert get_row_count(cursor0, h_agg_table) == 1
+    assert cursor0.execute(sel_prncase_str).fetchone()[0] is None
+
+    # WHEN
+    cursor0.execute(get_update_prncase_inx_epoch_diff_sqlstr())
+
+    # THEN
+    assert get_row_count(cursor0, h_agg_table) == 1
+    after_inx_epoch_diff = cursor0.execute(sel_prncase_str).fetchone()[0]
+    assert after_inx_epoch_diff
+    assert after_inx_epoch_diff == otx_time - inx_time
+    assert after_inx_epoch_diff == 186

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pchap1.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pchap1.py
@@ -1,0 +1,161 @@
+from sqlite3 import Cursor
+from src.ch00_py.db_toolbox import create_type_reference_insert_sqlstr
+from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
+from src.ch18_world_etl.etl_config import create_prime_tablename
+from src.ch18_world_etl.etl_sqlstr import (
+    create_prime_db_table,
+    get_update_prncase_context_plan_sqlstr,
+)
+from src.ch18_world_etl.test._util.ch18_env import cursor0
+from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
+
+
+def pchap1_insert_prncase(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.reason_context]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.reason_context]
+    tablename = create_prime_db_table(cursor0, kw.prncase, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def pchap1_insert_prnplan(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]
+    tablename = create_prime_db_table(cursor0, kw.prnplan, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def pchap1_select_prncase(cursor0: Cursor, print_rows: bool = False) -> list[tuple]:
+    """SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph"""
+    prncase_h_agg_table = create_prime_tablename(kw.prncase, "h", "agg", "put")
+    sel_prncase_str = f"""
+SELECT spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph 
+FROM {prncase_h_agg_table}
+ORDER BY spark_num, person_name, reason_context, context_plan_close, context_plan_denom, context_plan_morph
+;"""
+    x_rows = cursor0.execute(sel_prncase_str).fetchall()
+    if print_rows:
+        print(x_rows)
+    return x_rows
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario0_1row(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope]]
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    prncase_insert_sql = pchap1_insert_prncase(cursor0, prncase_vals)
+    prnplan_in_vals = [[spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph]]
+    prnplan_insert_sql = pchap1_insert_prnplan(cursor0, prnplan_in_vals)
+    assert pchap1_select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None)
+    ]
+
+    # WHEN
+    cursor0.execute(get_update_prncase_context_plan_sqlstr())
+
+    # THEN
+    assert pchap1_select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph)
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario1_2rows(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7, spark9 = (7, 9)
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pchap1_insert_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark9, exx.sue, wx.clean_rope]]
+    prncase_insert_sql = pchap1_insert_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert pchap1_select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark9, exx.sue, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pchap1_select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario3_DifferentPersons(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pchap1_insert_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.zia, wx.clean_rope]]
+    prncase_insert_sql = pchap1_insert_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert pchap1_select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.zia, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pchap1_select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prncase_context_plan_sqlstr_SQLTEST_Scenario4_Different_plan_rope(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pchap1_insert_prnplan(cursor0, prnplan_in_vals)
+    prncase_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.sue, wx.mop_rope]]
+    prncase_insert_sql = pchap1_insert_prncase(cursor0, prncase_vals)
+
+    # BEFORE
+    assert pchap1_select_prncase(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.sue, wx.mop_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prncase_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pchap1_select_prncase(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph),
+    ]

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pfhap0.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pfhap0.py
@@ -1,0 +1,46 @@
+from sqlite3 import Cursor
+from src.ch00_py.db_toolbox import get_row_count
+from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
+from src.ch18_world_etl.etl_config import create_prime_tablename
+from src.ch18_world_etl.etl_sqlstr import (
+    create_sound_and_heard_tables,
+    get_update_prnfact_inx_epoch_diff_sqlstr,
+)
+from src.ch18_world_etl.obj2db_person import insert_h_agg_obj
+from src.ch18_world_etl.test._util.ch18_env import cursor0
+from src.ch18_world_etl.test._util.ch18_examples import (
+    get_bob_five_with_mop_dayly,
+    insert_nabtime_h_agg_otx_inx_time as insert_otx_inx_time,
+)
+from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
+
+
+def test_get_update_prnfact_inx_epoch_diff_sqlstr_Scenario0_Simple_SetColumnValues(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    bob_person = get_bob_five_with_mop_dayly()
+    bob_person.add_fact(wx.time_rope, wx.time_rope, 0, 100)
+    create_sound_and_heard_tables(cursor0)
+    h_agg_table = create_prime_tablename(kw.prnfact, "h", "agg", "put")
+    otx_time = 199
+    inx_time = 13
+    moment_rope = bob_person.planroot.get_plan_rope()
+    insert_otx_inx_time(cursor0, spark7, exx.yao, moment_rope, otx_time, inx_time)
+    insert_h_agg_obj(cursor0, bob_person, spark7, exx.yao)
+    # TODO create SQL query that selects only the fields of interest (ok that it cannot be reused in other tests)
+    print(f"{h_agg_table=}")
+    sel_prnfact_str = f"SELECT {kw.inx_epoch_diff} FROM {h_agg_table};"
+    assert get_row_count(cursor0, h_agg_table) == 1
+    assert cursor0.execute(sel_prnfact_str).fetchone()[0] is None
+
+    # WHEN
+    cursor0.execute(get_update_prnfact_inx_epoch_diff_sqlstr())
+
+    # THEN
+    assert get_row_count(cursor0, h_agg_table) == 1
+    after_inx_epoch_diff = cursor0.execute(sel_prnfact_str).fetchone()[0]
+    assert after_inx_epoch_diff
+    assert after_inx_epoch_diff == otx_time - inx_time
+    assert after_inx_epoch_diff == 186

--- a/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pfhap1.py
+++ b/src/ch18_world_etl/test/z_heard/test_heard_agg_update_reasonnum_pfhap1.py
@@ -1,0 +1,162 @@
+from sqlite3 import Cursor
+from src.ch00_py.db_toolbox import create_type_reference_insert_sqlstr
+from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
+from src.ch18_world_etl.etl_config import create_prime_tablename
+from src.ch18_world_etl.etl_sqlstr import (
+    create_prime_db_table,
+    get_update_prnfact_context_plan_sqlstr,
+)
+from src.ch18_world_etl.test._util.ch18_env import cursor0
+from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
+
+
+def pfhap1_insert_prnfact(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.fact_context]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.fact_context]
+    tablename = create_prime_db_table(cursor0, kw.prnfact, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def pfhap1_insert_prnplan(cursor0: Cursor, x_values: list[list]) -> str:
+    """x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]"""
+    x_cols = [kw.spark_num, kw.person_name, kw.plan_rope, kw.close, kw.denom, kw.morph]
+    tablename = create_prime_db_table(cursor0, kw.prnplan, "h", "agg", "put")
+    insert_sql = create_type_reference_insert_sqlstr(tablename, x_cols, x_values)
+    cursor0.execute(insert_sql)
+    return insert_sql
+
+
+def pfhap1_select_prnfact(cursor0: Cursor, print_rows: bool = False) -> list[tuple]:
+    """SELECT spark_num, person_name, fact_context, context_plan_close, context_plan_denom, context_plan_morph"""
+    prnfact_h_agg_table = create_prime_tablename(kw.prnfact, "h", "agg", "put")
+    sel_prnfact_str = f"""
+SELECT spark_num, person_name, fact_context, context_plan_close, context_plan_denom, context_plan_morph 
+FROM {prnfact_h_agg_table}
+ORDER BY spark_num, person_name, fact_context, context_plan_close, context_plan_denom, context_plan_morph
+;"""
+    x_rows = cursor0.execute(sel_prnfact_str).fetchall()
+    if print_rows:
+        print(x_rows)
+    return x_rows
+
+
+def test_test_get_update_prnfact_context_plan_sqlstr_SQLTEST_Scenario0_1row(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    prnfact_vals = [[spark7, exx.sue, wx.clean_rope]]
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    prnfact_insert_sql = pfhap1_insert_prnfact(cursor0, prnfact_vals)
+    prnplan_in_vals = [[spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph]]
+    prnplan_insert_sql = pfhap1_insert_prnplan(cursor0, prnplan_in_vals)
+    assert pfhap1_select_prnfact(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None)
+    ]
+
+    # WHEN
+    cursor0.execute(get_update_prnfact_context_plan_sqlstr())
+
+    # THEN
+    assert pfhap1_select_prnfact(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph)
+    ]
+
+
+def test_test_get_update_prnfact_context_plan_sqlstr_SQLTEST_Scenario1_2rows(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7, spark9 = (7, 9)
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pfhap1_insert_prnplan(cursor0, prnplan_in_vals)
+    print(prnplan_insert_sql)
+    prnfact_vals = [[spark7, exx.sue, wx.clean_rope], [spark9, exx.sue, wx.clean_rope]]
+    prnfact_insert_sql = pfhap1_insert_prnfact(cursor0, prnfact_vals)
+
+    # BEFORE
+    assert pfhap1_select_prnfact(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark9, exx.sue, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prnfact_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pfhap1_select_prnfact(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark9, exx.sue, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prnfact_context_plan_sqlstr_SQLTEST_Scenario3_DifferentPersons(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pfhap1_insert_prnplan(cursor0, prnplan_in_vals)
+    prnfact_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.zia, wx.clean_rope]]
+    prnfact_insert_sql = pfhap1_insert_prnfact(cursor0, prnfact_vals)
+
+    # BEFORE
+    assert pfhap1_select_prnfact(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.zia, wx.clean_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prnfact_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pfhap1_select_prnfact(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.zia, wx.clean_rope, x1_close, x1_denom, x1_morph),
+    ]
+
+
+def test_test_get_update_prnfact_context_plan_sqlstr_SQLTEST_Scenario4_Different_plan_rope(
+    cursor0: Cursor,
+):
+    # ESTABLISH
+    spark7 = 7
+    x0_close, x0_denom, x0_morph = (44, 55, 66)
+    x1_close, x1_denom, x1_morph = (77, 88, 99)
+    prnplan_in_vals = [
+        [spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph],
+        [spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph],
+    ]
+    prnplan_insert_sql = pfhap1_insert_prnplan(cursor0, prnplan_in_vals)
+    prnfact_vals = [[spark7, exx.sue, wx.clean_rope], [spark7, exx.sue, wx.mop_rope]]
+    prnfact_insert_sql = pfhap1_insert_prnfact(cursor0, prnfact_vals)
+
+    # BEFORE
+    assert pfhap1_select_prnfact(cursor0) == [
+        (spark7, exx.sue, wx.clean_rope, None, None, None),
+        (spark7, exx.sue, wx.mop_rope, None, None, None),
+    ]
+
+    # WHEN
+    update_sql = get_update_prnfact_context_plan_sqlstr()
+    cursor0.execute(update_sql)
+
+    # THEN
+    assert pfhap1_select_prnfact(cursor0, True) == [
+        (spark7, exx.sue, wx.clean_rope, x0_close, x0_denom, x0_morph),
+        (spark7, exx.sue, wx.mop_rope, x1_close, x1_denom, x1_morph),
+    ]

--- a/src/ch18_world_etl/test/z_sound/test_sound_agg_tables_to_translate_core_tables.py
+++ b/src/ch18_world_etl/test/z_sound/test_sound_agg_tables_to_translate_core_tables.py
@@ -825,7 +825,6 @@ def test_create_update_trltitl_sound_agg_knot_error_sqlstr_PopulatesTable_Scenar
 , {kw.otx_title}
 , {kw.inx_title}
 )"""
-    # TODO create values where errors will appear: groups should map to groups,
     values_clause = f"""
 VALUES
   ({spark1}, '{exx.bob}', '{sue_otx}', '{sue_inx}')

--- a/src/ch98_docs_builder/test/test_keyword_descriptions.py
+++ b/src/ch98_docs_builder/test/test_keyword_descriptions.py
@@ -5,6 +5,7 @@ from src.ch13_time.epoch_main import get_c400_constants, get_default_epoch_confi
 from src.ch14_moment.moment_config import get_moment_config_args
 from src.ch15_nabu.nabu_config import get_nabu_args, get_nabuable_args
 from src.ch16_translate.translate_config import get_translate_config_args
+from src.ch18_world_etl.etl_main import etl_heard_raw_tables_to_moment_ote1_agg
 from src.ch98_docs_builder._ref.ch98_semantic_types import (
     BreakTerm,
     CRUD_command,
@@ -153,8 +154,11 @@ def test_get_keywords_description_ReturnsObj_CheckDescriptions():
             assert keyword in doc_str_semantic_types
     for semantic_class, class_doc_str in all_semantic_types_with_doc_strs.items():
         semantic_description = keywords_description.get(semantic_class)
-        print(f"{semantic_class=} {class_doc_str=}")
+        # print(f"{semantic_class=} {class_doc_str=}")
         assert class_doc_str in semantic_description
+
+    moment_ote1_agg_desc = inspect_getdoc(etl_heard_raw_tables_to_moment_ote1_agg)
+    assert moment_ote1_agg_desc in keywords_description.get("moment_ote1_agg")
 
 
 def get_all_semantic_types_with_doc_strs() -> dict[str, str]:

--- a/src/linter/style.py
+++ b/src/linter/style.py
@@ -39,16 +39,24 @@ def function_name_style_is_correct(function_name: str):
     if not function_name.startswith("test") and "None" not in function_name:
         return uppercase_in_str(function_name) is False
     elif "scenario" in function_name:
+        print(f"{function_name} has scenario")
         return False
     else:
         func_lower = function_name.lower()
         if func_lower.endswith("exists") and not function_name.endswith("Exists"):
+            print(f"{function_name} and Exists")
             return False
         elif "returnsobj" in func_lower and "ReturnsObj" not in function_name:
+            print(f"rtr{func_lower=}")
             return False
         elif "returnobj" in func_lower:
+            print(f"sdfas{func_lower=}")
             return False
-        return uppercase_in_str(function_name)
+        uppercase_in_str_bool = uppercase_in_str(function_name)
+        if not uppercase_in_str_bool:
+            print(f"{function_name=}")
+            print(f"{uppercase_in_str(function_name)=}")
+        return uppercase_in_str_bool
 
 
 def get_imports_from_file(file_path):

--- a/src/ref/keywords_description.json
+++ b/src/ref/keywords_description.json
@@ -1,5 +1,5 @@
 {
-  "active_requisite": ", Reason seed", 
+  "active_requisite": "Represents the expected boolean of the PlanUnit with address reason_context. If None, no check. If False expected Active bool of reason_context PlanUnit is false. If True expected contest_plan.active is True, Reason seed", 
   "addin": "float that describes addition to parent range calculations, Plan seed", 
   "all_partner_cred": ", Plan conpute", 
   "all_partner_debt": ", Plan conpute", 
@@ -221,7 +221,7 @@
   "moment_kpi001_partner_nets": "TODO", 
   "moment_kpi002_person_pledges": "TODO", 
   "moment_mstr_dir": "TODO", 
-  "moment_ote1_agg": "TODO", 
+  "moment_ote1_agg": "Create Database Table that holds all spark_num to bud_time pairs. Include moment_rope and person_name", 
   "moment_partner_nets": "TODO", 
   "moment_paybook": "TODO", 
   "moment_rope": ", Moment arg, offi_time arg, paybook arg, mmtweek arg, mmtmont arg, mmthour arg, bud arg, Person seed, Plan seed, Reason seed, Case seed, Fact seed, Award seed, Labor seed, Healer seed, Partner seed, Member seed, nabu arg.", 


### PR DESCRIPTION
## Summary by Sourcery

Update ETL SQL generation and tests to support multi-row inserts, refined context-plan joins, and new dimension abbreviations while adding targeted SQL integration tests for heard/fact updates.

New Features:
- Add support for generating multi-row SQL INSERT statements and using them across atom and ETL insertion paths.
- Introduce helper to create a single prime DB table from dimension and stage identifiers.
- Add 2-character dimension abbreviations and validation ensuring coverage of all configured dimensions.
- Add new SQL-level tests for updating inx_epoch_diff and context_plan* fields for reason and fact heard aggregates.

Bug Fixes:
- Fix incorrect dimension/table keys in heard aggregate epoch-diff tests and align nabu time table naming.
- Correct data types for context_plan_close, context_plan_denom, and context_plan_morph columns to REAL in heard aggregate schemas and idea config.
- Align generated INSERT SQL formatting with expectations in PersonAtom tests and dict capitalization checks.

Enhancements:
- Refine context-plan update SQL to join directly between heard aggregates and plan tables on spark, person, and context/plan_rope.
- Improve linter function-name style checks and add coverage for strings without uppercase characters.
- Add docstring-based validation for moment_ote1_agg keyword descriptions and minor logging/printing cleanups in tests and helpers.
- Document and compute inx_epoch_diff updates for heard aggregates via clearer helper functions and reference keys.

Tests:
- Add comprehensive SQL integration tests for prncase/prnfact context_plan* propagation from prnplan across multiple matching scenarios.
- Add tests for multi-row insert SQL generation, including handling of None values and actual insertion into SQLite.
- Extend ETL table tests to validate completeness of 7-char and new 2-char dimension abbreviations.