### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch13_time/epoch_main.py
+++ b/src/ch13_time/epoch_main.py
@@ -166,7 +166,7 @@ def get_epoch_length(epoch_config: dict) -> int:
 
 def add_epoch_planunit(x_personunit: PersonUnit, epoch_config: dict = None):
     """Add epoch plan to PersonUnit from epoch_config. epoch_config defaults to creg epoch_config"""
-    if not epoch_config:
+    if epoch_config is None:
         epoch_config = get_default_epoch_config_dict()
 
     x_plan_label = epoch_config.get("epoch_label")

--- a/src/ch25_google_calendar/gcalendar.py
+++ b/src/ch25_google_calendar/gcalendar.py
@@ -51,14 +51,15 @@ def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[di
             end_date = day + timedelta(minutes=day_case.reason_upper)
             event_dict = {
                 "Subject": event_subject,
-                "Start Date": start_date.isoformat(),
-                "End Date": end_date.isoformat(),
+                "Start Date": start_date.strftime("%m/%d/%Y"),
+                "Start Time": start_date.strftime("%I:%M %p"),
+                "End Date": end_date.strftime("%m/%d/%Y"),
+                "End Time": end_date.strftime("%I:%M %p"),
                 "All Day Event": "False",
                 "Description": agenda_item.get_plan_rope(),
             }
             day_events.append(event_dict)
-        else:
-            gcal_tobe_description += f"{event_subject}\n"
+        gcal_tobe_description += f"{event_subject}\n"
     all_day_events = {
         "Subject": "Pledges",
         "Start Date": day.strftime("%m/%d/%Y"),
@@ -92,6 +93,8 @@ def create_gcalendar_csv_from_list(events: list[dict]) -> str:
     return output.getvalue()
 
 
-def create_gcalendar_csv_from_person(x_person: PersonUnit, day: datetime) -> str:
+def create_gcalendar_csv_from_person(x_person: PersonUnit, day: datetime = None) -> str:
+    if day is None:
+        day = datetime.combine(datetime.now().date(), datetime.min.time())
     events_list = create_gcalendar_events_list(x_person, day)
     return create_gcalendar_csv_from_list(events_list)

--- a/src/ch25_google_calendar/gcalendar.py
+++ b/src/ch25_google_calendar/gcalendar.py
@@ -11,7 +11,7 @@ from src.ch13_time.epoch_main import (
 from src.ch13_time.epoch_reason import set_epoch_base_case_dayly, set_epoch_fact
 
 
-def gcal_readble_percent(value: float, precision=2):
+def gcal_readable_percent(value: float, precision=2):
     """
     Convert a float into a readable percentage string.
     Handles very small and large values gracefully.
@@ -30,7 +30,6 @@ def gcal_readble_percent(value: float, precision=2):
 
 def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[dict]:
     default_epoch_config = get_default_epoch_config_dict()
-    add_epoch_planunit(x_person, default_epoch_config)
     default_epoch_label = default_epoch_config.get("epoch_label")
     epoch_min_lower = get_epoch_min_from_dt(x_person, default_epoch_label, day)
     next_day = day + timedelta(days=1)
@@ -43,7 +42,7 @@ def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[di
     gcal_tobe_description = ""
     day_events = []
     for item_rank, agenda_item in enumerate(agenda_list, start=1):
-        item_fund_ratio_str = gcal_readble_percent(agenda_item.fund_ratio)
+        item_fund_ratio_str = gcal_readable_percent(agenda_item.fund_ratio)
         event_subject = f"{item_rank}. {agenda_item.plan_label} ({item_fund_ratio_str})"
         day_reasonheir = agenda_item.get_reasonheir(epoch_day_rope)
         if day_reasonheir:

--- a/src/ch25_google_calendar/test/test_gcal_exportcsv.py
+++ b/src/ch25_google_calendar/test/test_gcal_exportcsv.py
@@ -261,8 +261,7 @@ def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge()
     assert expected_csv_line3 in sue_gcal_csv
 
 
-def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge():
-    # ESTABLISH
+def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario1_Non_all_day_EventExists():
     # ESTABLISH
     sue_person = personunit_shop(wx.sue, wx.a23)
     sue_person.add_plan(wx.sweep_rope, pledge=True, star=1)

--- a/src/ch25_google_calendar/test/test_gcal_exportcsv.py
+++ b/src/ch25_google_calendar/test/test_gcal_exportcsv.py
@@ -1,5 +1,5 @@
 from csv import DictReader as csv_DictReader
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import StringIO as io_StringIO
 from src.ch07_person_logic.person_main import personunit_shop
 from src.ch13_time.epoch_main import add_epoch_planunit, get_default_epoch_config_dict
@@ -161,7 +161,8 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario3_OneEpoch_pledge():
     sue_gcal_events = create_gcalendar_events_list(sue_person, apr7)
 
     # THEN
-    gcal_tobe_description = f"""2. {wx.sweep_str} (33.33%)
+    gcal_tobe_description = f"""1. {wx.mop_str} (66.67%)
+2. {wx.sweep_str} (33.33%)
 """
     description_str = "Description"
     start_date_str = "Start Date"
@@ -173,7 +174,6 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario3_OneEpoch_pledge():
         "All Day Event": "True",
         description_str: gcal_tobe_description,
     }
-    print(sue_gcal_events)
     init_gcal_event = sue_gcal_events[1]
     assert len(sue_gcal_events) == 2
     assert init_gcal_event.get(description_str) == gcal_tobe_description
@@ -182,8 +182,10 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario3_OneEpoch_pledge():
     print(sue_gcal_events[0])
     expected_mop_event = {
         "Subject": f"1. {wx.mop_str} (66.67%)",
-        start_date_str: "2010-05-07T10:00:00",
-        "End Date": "2010-05-07T11:30:00",
+        start_date_str: expected_apr7str,
+        "Start Time": "10:00 AM",
+        "End Date": expected_apr7str,
+        "End Time": "11:30 AM",
         "All Day Event": "False",
         description_str: wx.mop_rope,
     }
@@ -254,8 +256,10 @@ def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge()
     expected_csv_line1 = (
         "Subject,Start Date,Start Time,End Date,End Time,All Day Event,Description"
     )
-    expected_csv_line2 = "1. mop (66.67%),2010-05-07T10:00:00,,2010-05-07T11:30:00,,False,;Amy23;casa;clean;mop;"
-    expected_csv_line3 = """Pledges,05/07/2010,,05/07/2010,,True,"2. sweep (33.33%)"""
+    expected_csv_line2 = "1. mop (66.67%),05/07/2010,10:00 AM,05/07/2010,11:30 AM,False,;Amy23;casa;clean;mop;"
+    expected_csv_line3 = (
+        """Pledges,05/07/2010,,05/07/2010,,True,"1. mop (66.67%)\n2. sweep (33.33%)\n"""
+    )
     assert expected_csv_line1 in sue_gcal_csv
     assert expected_csv_line2 in sue_gcal_csv
     assert expected_csv_line3 in sue_gcal_csv
@@ -283,8 +287,45 @@ def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario1_Non_all_day_Event
     expected_csv_line1 = (
         "Subject,Start Date,Start Time,End Date,End Time,All Day Event,Description"
     )
-    expected_csv_line2 = "1. mop (66.67%),2010-05-07T10:00:00,,2010-05-07T11:30:00,,False,;Amy23;casa;clean;mop;"
-    expected_csv_line3 = """Pledges,05/07/2010,,05/07/2010,,True,"2. sweep (33.33%)"""
+    expected_csv_line2 = "1. mop (66.67%),05/07/2010,10:00 AM,05/07/2010,11:30 AM,False,;Amy23;casa;clean;mop;"
+    expected_csv_line3 = (
+        """Pledges,05/07/2010,,05/07/2010,,True,"1. mop (66.67%)\n2. sweep (33.33%)\n"""
+    )
     assert expected_csv_line1 in sue_gcal_csv
+    assert expected_csv_line2 in sue_gcal_csv
+    assert expected_csv_line3 in sue_gcal_csv
+
+
+def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario2_TodayEvents():
+    # ESTABLISH
+    sue_person = personunit_shop(wx.sue, wx.a23)
+    sue_person.add_plan(wx.sweep_rope, pledge=True, star=1)
+
+    # add mop task but only at a point during the day
+    sue_person.add_plan(wx.mop_rope, pledge=True, star=2)
+    default_epoch_config = get_default_epoch_config_dict()
+    default_epoch_label = default_epoch_config.get(kw.epoch_label)
+    add_epoch_planunit(sue_person, default_epoch_config)
+    set_epoch_base_case_dayly(sue_person, wx.mop_rope, default_epoch_label, 600, 90)
+    apr7 = datetime(2010, 5, 7)
+
+    # WHEN
+    sue_gcal_csv = create_gcalendar_csv_from_person(sue_person)
+
+    # THEN
+    expected_start_date = datetime.now().date()
+    expected_start_date_str = expected_start_date.strftime("%m/%d/%Y")
+    expected_end_date = expected_start_date + timedelta(days=1)
+    expected_end_date_str = expected_end_date.strftime("%m/%d/%Y")
+    print(sue_gcal_csv)
+    expected_csv_line1 = (
+        "Subject,Start Date,Start Time,End Date,End Time,All Day Event,Description"
+    )
+    expected_csv_lv2 = f"1. mop (66.67%),03/15/2026,10:00 AM,03/15/2026,11:30 AM,False,;Amy23;casa;clean;mop;"
+    expected_csv_line2 = f"1. mop (66.67%),{expected_start_date_str},10:00 AM,{expected_start_date_str},11:30 AM,False,;Amy23;casa;clean;mop;"
+    expected_csv_line3 = f"""Pledges,{expected_start_date_str},,{expected_start_date_str},,True,"1. mop (66.67%)\n2. sweep (33.33%)\n"""
+    assert expected_csv_line1 in sue_gcal_csv
+    assert expected_csv_lv2 in sue_gcal_csv
+    assert expected_csv_lv2 == expected_csv_line2
     assert expected_csv_line2 in sue_gcal_csv
     assert expected_csv_line3 in sue_gcal_csv

--- a/src/ch25_google_calendar/test/test_gcal_exportcsv.py
+++ b/src/ch25_google_calendar/test/test_gcal_exportcsv.py
@@ -9,33 +9,35 @@ from src.ch25_google_calendar.gcalendar import (
     create_gcalendar_csv_from_list,
     create_gcalendar_csv_from_person,
     create_gcalendar_events_list,
-    gcal_readble_percent,
+    gcal_readable_percent,
 )
 from src.ref.keywords import Ch25Keywords as kw
 
 
-def test_gcal_readble_percent_ReturnsObj():
+def test_gcal_readable_percent_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    assert gcal_readble_percent(1.0) == "100%"
+    assert gcal_readable_percent(1.0) == "100%"
     """Ensure trailing zeros and decimal points are removed properly."""
-    assert gcal_readble_percent(0.5) == "50%"
-    assert gcal_readble_percent(0.505) == "50.5%"
-    assert gcal_readble_percent(0.5001) == "50.01%"
+    assert gcal_readable_percent(0.5) == "50%"
+    assert gcal_readable_percent(0.505) == "50.5%"
+    assert gcal_readable_percent(0.5001) == "50.01%"
     """Ensure extremely small numbers use scientific notation."""
-    result = gcal_readble_percent(1e-10)
+    result = gcal_readable_percent(1e-10)
     assert "e" in result
     assert result.endswith("%")
     """Ensure custom precision works correctly."""
-    assert gcal_readble_percent(0.123456, precision=1) == "12.3%"
-    assert gcal_readble_percent(0.123456, precision=4) == "12.3456%"
-    assert gcal_readble_percent(0.00123456, precision=4) == "0.1235%"
-    assert gcal_readble_percent(0.0000123456, precision=4) == "1.23e-03%"
-    assert gcal_readble_percent(0.000123456) == "0.01%"
+    assert gcal_readable_percent(0.123456, precision=1) == "12.3%"
+    assert gcal_readable_percent(0.123456, precision=4) == "12.3456%"
+    assert gcal_readable_percent(0.00123456, precision=4) == "0.1235%"
+    assert gcal_readable_percent(0.0000123456, precision=4) == "1.23e-03%"
+    assert gcal_readable_percent(0.000123456) == "0.01%"
 
 
 def test_create_gcalendar_events_list_ReturnsObj_Scenario0_Empty():
     # ESTABLISH
     sue_person = personunit_shop(wx.sue, wx.a23)
+    default_epoch_config = get_default_epoch_config_dict()
+    add_epoch_planunit(sue_person, default_epoch_config)
     apr7 = datetime(2010, 5, 7, 9)
     print(f"{apr7=}")
 
@@ -74,6 +76,8 @@ def test_PersonUnit_conpute_SetsAttr_ScenarioX_SingleBranch_fund_ratio():
 def test_create_gcalendar_events_list_ReturnsObj_Scenario1_1AllDayPledge():
     # ESTABLISH
     sue_person = personunit_shop(wx.sue, wx.a23)
+    default_epoch_config = get_default_epoch_config_dict()
+    add_epoch_planunit(sue_person, default_epoch_config)
     sue_person.add_plan(wx.mop_rope, pledge=True, star=1)
     apr7 = datetime(2010, 5, 7, 9)
     print(f"{apr7=}")
@@ -103,6 +107,8 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario1_1AllDayPledge():
 def test_create_gcalendar_events_list_ReturnsObj_Scenario2_3AllDayPledge():
     # ESTABLISH
     sue_person = personunit_shop(wx.sue, wx.a23)
+    default_epoch_config = get_default_epoch_config_dict()
+    add_epoch_planunit(sue_person, default_epoch_config)
     sue_person.add_plan(wx.mop_rope, pledge=True, star=2)
     sue_person.add_plan(wx.sweep_rope, pledge=True, star=1)
     sue_person.add_plan(wx.scrub_rope, pledge=True, star=1)
@@ -239,6 +245,36 @@ def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge()
     add_epoch_planunit(sue_person, default_epoch_config)
     set_epoch_base_case_dayly(sue_person, wx.mop_rope, default_epoch_label, 600, 90)
     apr7 = datetime(2010, 5, 7)
+
+    # WHEN
+    sue_gcal_csv = create_gcalendar_csv_from_person(sue_person, apr7)
+
+    # THEN
+    print(sue_gcal_csv)
+    expected_csv_line1 = (
+        "Subject,Start Date,Start Time,End Date,End Time,All Day Event,Description"
+    )
+    expected_csv_line2 = "1. mop (66.67%),2010-05-07T10:00:00,,2010-05-07T11:30:00,,False,;Amy23;casa;clean;mop;"
+    expected_csv_line3 = """Pledges,05/07/2010,,05/07/2010,,True,"2. sweep (33.33%)"""
+    assert expected_csv_line1 in sue_gcal_csv
+    assert expected_csv_line2 in sue_gcal_csv
+    assert expected_csv_line3 in sue_gcal_csv
+
+
+def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge():
+    # ESTABLISH
+    # ESTABLISH
+    sue_person = personunit_shop(wx.sue, wx.a23)
+    sue_person.add_plan(wx.sweep_rope, pledge=True, star=1)
+
+    # add mop task but only at a point during the day
+    sue_person.add_plan(wx.mop_rope, pledge=True, star=2)
+    default_epoch_config = get_default_epoch_config_dict()
+    default_epoch_label = default_epoch_config.get(kw.epoch_label)
+    add_epoch_planunit(sue_person, default_epoch_config)
+    set_epoch_base_case_dayly(sue_person, wx.mop_rope, default_epoch_label, 600, 90)
+    apr7 = datetime(2010, 5, 7)
+    print(f"{apr7=}")
 
     # WHEN
     sue_gcal_csv = create_gcalendar_csv_from_person(sue_person, apr7)


### PR DESCRIPTION
## Summary by Sourcery

Adjust Google Calendar export formatting and epoch configuration handling for person schedules.

Bug Fixes:
- Correct misspelled gcal_readable_percent helper name and its test references.
- Ensure epoch configuration is only auto-created when None rather than any falsy value.

Enhancements:
- Format timed Google Calendar events using separate date and 12-hour time fields compatible with CSV export.
- Always include pledge items in the all-day description list while generating daily events.
- Allow create_gcalendar_csv_from_person to default to generating events for today when no date is provided.
- Update tests to cover mixed all-day and timed events and today-default behavior.