### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch19_world_kpi/gcalendar.py
+++ b/src/ch19_world_kpi/gcalendar.py
@@ -151,7 +151,7 @@ def get_gcal_all_agenda_str(
     agenda_list = get_sorted_plan_list(agenda_plans_dict, "fund_ratio")
     moment_rope = x_person.planroot.get_plan_rope()
     epoch_rope = get_epoch_rope(moment_rope, epoch_label, x_person.knot)
-    gcal_agenda_list_str = ""
+    gcal_agenda_list_str = "All Agenda Items"
     for item_rank, agenda_item in enumerate(agenda_list, start=1):
         item_fund_ratio_str = gcal_readable_percent(agenda_item.fund_ratio)
         event_subject = f"{item_rank}. {agenda_item.plan_label} ({item_fund_ratio_str})"
@@ -166,7 +166,7 @@ def get_gcal_all_agenda_str(
                 clock_upper = minute_to_clock_time(day_reason_upper)
                 clock_range = f" {clock_lower}-{clock_upper}"
                 event_subject += clock_range
-        gcal_agenda_list_str += f"{event_subject}\n"
+        gcal_agenda_list_str += f"\n{event_subject}"
     return gcal_agenda_list_str
 
 
@@ -206,6 +206,25 @@ def get_gcal_memberships_str(x_person: PersonUnit, group_title: GroupTitle) -> s
     return create_partners_only_list_str(partners_list, x_str)
 
 
+def get_gcal_day_report(
+    x_person: PersonUnit,
+    day: datetime,
+    epoch_label: LabelTerm = None,
+    group_title: GroupTitle = None,
+) -> str:
+    """parameter x_person is assumed to have already conputed."""
+    x_str = f"Day Report for {x_person.person_name}\n"
+    if not epoch_label:
+        epoch_label = get_default_epoch_config_dict().get("epoch_label")
+    x_dayevents = get_dayevents(x_person, epoch_label, day)
+    x_str += f"\n{get_gcal_priorities_schedule_str(x_dayevents)}"
+    x_str += f"\n{get_gcal_all_agenda_str(x_person, epoch_label, day)}"
+    x_str += f"\n{get_gcal_partners_str(x_person)}"
+    if group_title:
+        x_str += f"\n{get_gcal_memberships_str(x_person, group_title)}"
+    return x_str
+
+
 def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[dict]:
     x_person = copy_deepcopy(x_person)
     default_epoch_config = get_default_epoch_config_dict()
@@ -237,7 +256,7 @@ def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[di
         "All Day Event": "True",
         "Description": gcal_agenda_list_str,
     }
-    if gcal_agenda_list_str != "":
+    if x_person.get_agenda_dict() != {}:
         day_events.append(all_day_events)
     return day_events
 

--- a/src/ch19_world_kpi/gcalendar.py
+++ b/src/ch19_world_kpi/gcalendar.py
@@ -3,6 +3,7 @@ from csv import DictWriter as csv_DictWriter
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from io import StringIO as io_StringIO
+from src.ch02_partner.partner import PartnerUnit
 from src.ch04_rope.rope import is_sub_rope
 from src.ch05_reason.reason_main import ReasonHeir
 from src.ch06_plan.plan import PlanUnit
@@ -13,7 +14,7 @@ from src.ch13_time.epoch_main import (
     get_epoch_rope,
 )
 from src.ch13_time.epoch_reason import set_epoch_fact
-from src.ch19_world_kpi._ref.ch19_semantic_types import LabelTerm, RopeTerm
+from src.ch19_world_kpi._ref.ch19_semantic_types import GroupTitle, LabelTerm, RopeTerm
 
 
 def gcal_readable_percent(value: float, precision=2):
@@ -49,13 +50,17 @@ def planunit_is_scheduled_in_day(reasonheir: ReasonHeir, epoch_rope) -> bool:
     return False
 
 
-def get_dayevents(
-    person: PersonUnit, epoch_label: LabelTerm, day: datetime
-) -> list[DayEvent]:
+def set_day_epoch_fact(person: PersonUnit, epoch_label: LabelTerm, day: datetime):
     epoch_min_lower = get_epoch_min_from_dt(person, epoch_label, day)
     next_day = day + timedelta(days=1)
     epoch_min_upper = get_epoch_min_from_dt(person, epoch_label, next_day)
     set_epoch_fact(person, epoch_label, epoch_min_lower, epoch_min_upper)
+
+
+def get_dayevents(
+    person: PersonUnit, epoch_label: LabelTerm, day: datetime
+) -> list[DayEvent]:
+    set_day_epoch_fact(person, epoch_label, day)
 
     moment_rope = person.planroot.get_plan_rope()
     epoch_rope = get_epoch_rope(moment_rope, epoch_label, person.knot)
@@ -80,15 +85,15 @@ def get_dayevents(
     return dayevents
 
 
-def get_inflection_points_dict(dayevents: list[DayEvent]) -> dict[int, PlanUnit]:
+def get_inflection_points_dict(dayevents: list[DayEvent]) -> dict[int, DayEvent | None]:
     """
-    Returns a list of (time, event) tuples representing inflection points �
-    moments where the "most important active event" changes.
+    Returns a dict[day_minute, DayEvent] representing inflection day_minutes where the
+    "most important active event" changes.
 
     An inflection point occurs when:
     - A more important event starts while another is ongoing
     - The current top event ends and a different one takes over (or nothing)
-    - A gap exists between events (represented as (time, None))
+    - A gap exists between events (represented as day_minute: None)
     """
     # Collect all relevant timestamps
     timestamps = sorted(
@@ -140,10 +145,7 @@ def get_gcal_priorities_schedule_str(dayevents: list[DayEvent]) -> str:
 def get_gcal_all_agenda_str(
     x_person: PersonUnit, epoch_label: LabelTerm, day: datetime
 ) -> str:
-    epoch_min_lower = get_epoch_min_from_dt(x_person, epoch_label, day)
-    next_day = day + timedelta(days=1)
-    epoch_min_upper = get_epoch_min_from_dt(x_person, epoch_label, next_day)
-    set_epoch_fact(x_person, epoch_label, epoch_min_lower, epoch_min_upper)
+    set_day_epoch_fact(x_person, epoch_label, day)
 
     agenda_plans_dict = x_person.get_agenda_dict()
     agenda_list = get_sorted_plan_list(agenda_plans_dict, "fund_ratio")
@@ -171,6 +173,10 @@ def get_gcal_all_agenda_str(
 def get_gcal_partners_str(x_person: PersonUnit) -> str:
     x_str = "Person Partners"
     partners_list = list(x_person.partners.values())
+    return create_partners_only_list_str(partners_list, x_str)
+
+
+def create_partners_only_list_str(partners_list: list[PartnerUnit], x_str: str) -> str:
     partners_list.sort(
         key=lambda pu: (
             -pu.fund_agenda_ratio_give - pu.fund_agenda_ratio_take,
@@ -181,23 +187,33 @@ def get_gcal_partners_str(x_person: PersonUnit) -> str:
     for partner in partners_list:
         give_left = partner.fund_agenda_ratio_give - partner.fund_agenda_ratio_take
         agenda_relative_give = gcal_readable_percent(give_left)
-
         x_str += f"\n{agenda_relative_give} {partner.partner_name}"
     return x_str
+
+
+def get_gcal_memberships_str(x_person: PersonUnit, group_title: GroupTitle) -> str:
+    x_str = f"{group_title} Group"
+    groupunit = x_person.get_groupunit(group_title)
+    group_partner_names = []
+    if not groupunit or len(groupunit.memberships) == 0:
+        x_str += "\nNo memberships"
+    else:
+        for partner_name in groupunit.memberships.keys():
+            group_partner_names.append(partner_name)
+    partners_list = []
+    for group_partner_name in group_partner_names:
+        partners_list.append(x_person.get_partner(group_partner_name))
+    return create_partners_only_list_str(partners_list, x_str)
 
 
 def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[dict]:
     x_person = copy_deepcopy(x_person)
     default_epoch_config = get_default_epoch_config_dict()
-    default_epoch_label = default_epoch_config.get("epoch_label")
-    epoch_min_lower = get_epoch_min_from_dt(x_person, default_epoch_label, day)
-    next_day = day + timedelta(days=1)
-    epoch_min_upper = get_epoch_min_from_dt(x_person, default_epoch_label, next_day)
-    set_epoch_fact(x_person, default_epoch_label, epoch_min_lower, epoch_min_upper)
+    epoch_label = default_epoch_config.get("epoch_label")
 
     gcal_agenda_list_str = ""
     day_events = []
-    dayevent_objs = get_dayevents(x_person, default_epoch_label, day)
+    dayevent_objs = get_dayevents(x_person, epoch_label, day)
     for dayevent_obj in dayevent_objs:
         item_fund_ratio_str = gcal_readable_percent(dayevent_obj.plan.fund_ratio)
         event_subject = f"{dayevent_obj.item_rank}. {dayevent_obj.plan.plan_label} ({item_fund_ratio_str})"
@@ -213,7 +229,7 @@ def create_gcalendar_events_list(x_person: PersonUnit, day: datetime) -> list[di
             "Description": dayevent_obj.plan.get_plan_rope(),
         }
         day_events.append(event_dict)
-    gcal_agenda_list_str = get_gcal_all_agenda_str(x_person, default_epoch_label, day)
+    gcal_agenda_list_str = get_gcal_all_agenda_str(x_person, epoch_label, day)
     all_day_events = {
         "Subject": "Pledges",
         "Start Date": day.strftime("%m/%d/%Y"),

--- a/src/ch19_world_kpi/test/test_person_calendar/test_gcal__agenda_list.py
+++ b/src/ch19_world_kpi/test/test_person_calendar/test_gcal__agenda_list.py
@@ -1,10 +1,6 @@
 from datetime import datetime
 from src.ch07_person_logic.person_main import personunit_shop
-from src.ch13_time.epoch_main import (
-    add_epoch_planunit,
-    get_default_epoch_config_dict,
-    get_epoch_rope,
-)
+from src.ch13_time.epoch_main import add_epoch_planunit, get_default_epoch_config_dict
 from src.ch13_time.epoch_reason import set_epoch_base_case_dayly
 from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
 from src.ch19_world_kpi.gcalendar import (
@@ -109,8 +105,7 @@ def test_get_gcal_all_agenda_str_ReturnsObj_Scenario1_1AllDayPledge():
     bob_agenda_str = get_gcal_all_agenda_str(bob_person, epoch_label, day=apr7)
 
     # THEN
-    expected_gcal_agenda_list_str = f"""1. {wx.mop_str} (100%)
-"""
+    expected_gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (100%)"""
     assert bob_agenda_str == expected_gcal_agenda_list_str
 
 
@@ -130,10 +125,9 @@ def test_get_gcal_all_agenda_str_ReturnsObj_Scenario2_3AllDayPledge():
     bob_agenda_str = get_gcal_all_agenda_str(bob_person, epoch_label, day=apr7)
 
     # THEN
-    expected_gcal_agenda_list_str = f"""1. {wx.mop_str} (50%)
+    expected_gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (50%)
 2. {wx.scrub_str} (25%)
-3. {wx.sweep_str} (25%)
-"""
+3. {wx.sweep_str} (25%)"""
     assert bob_agenda_str == expected_gcal_agenda_list_str
 
 
@@ -155,8 +149,7 @@ def test_get_gcal_all_agenda_str_ReturnsObj_Scenario3_OneEpoch_pledge():
     bob_agenda_str = get_gcal_all_agenda_str(bob_person, default_epoch_label, apr7)
 
     # THEN
-    expected_gcal_agenda_list_str = f"""1. {wx.mop_str} (66.67%) 10:00 AM-11:30 AM
-2. {wx.sweep_str} (33.33%)
-"""
+    expected_gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (66.67%) 10:00 AM-11:30 AM
+2. {wx.sweep_str} (33.33%)"""
     print(f"{bob_agenda_str=}")
     assert bob_agenda_str == expected_gcal_agenda_list_str

--- a/src/ch19_world_kpi/test/test_person_calendar/test_gcal__agenda_list.py
+++ b/src/ch19_world_kpi/test/test_person_calendar/test_gcal__agenda_list.py
@@ -92,6 +92,7 @@ def test_gcal_readable_percent_ReturnsObj():
     assert gcal_readable_percent(0.00123456, precision=4) == "0.1235%"
     assert gcal_readable_percent(0.0000123456, precision=4) == "1.23e-03%"
     assert gcal_readable_percent(0.000123456) == "0.01%"
+    assert gcal_readable_percent(None) == "0%"
 
 
 def test_get_gcal_all_agenda_str_ReturnsObj_Scenario1_1AllDayPledge():

--- a/src/ch19_world_kpi/test/test_person_calendar/test_gcal__partners_list.py
+++ b/src/ch19_world_kpi/test/test_person_calendar/test_gcal__partners_list.py
@@ -1,6 +1,10 @@
 from src.ch07_person_logic.person_main import personunit_shop
 from src.ch13_time.test._util.ch13_examples import Ch13ExampleStrs as wx
-from src.ch19_world_kpi.gcalendar import gcal_readable_percent, get_gcal_partners_str
+from src.ch19_world_kpi.gcalendar import (
+    gcal_readable_percent,
+    get_gcal_memberships_str,
+    get_gcal_partners_str,
+)
 from src.ref.keywords import Ch19Keywords as kw, ExampleStrs as exx
 
 
@@ -44,3 +48,37 @@ def test_get_gcal_partners_str_ReturnsObj_Scenario2_TwoPartnersCorrectOrder():
 16.67% {exx.sue}
 -16.67% {exx.bob}"""
     assert gcal_partners_str == expected_gcal_partners_str
+
+
+def test_get_gcal_memberships_str_ReturnsObj_Scenario0_NoMembership():
+    # ESTABLISH
+    bob_person = personunit_shop(wx.Bob, wx.root_rope)
+    bob_person.add_partnerunit(exx.bob, 2)
+
+    # WHEN
+    run_memberships_str = get_gcal_memberships_str(bob_person, exx.run)
+
+    # THEN
+    assert run_memberships_str
+    expected_run_memberships_str = f"""{exx.run} Group\nNo memberships"""
+    print(run_memberships_str)
+    print(expected_run_memberships_str)
+    assert run_memberships_str == expected_run_memberships_str
+
+
+def test_get_gcal_memberships_str_ReturnsObj_Scenario1_TwoPartners():
+    # ESTABLISH
+    bob_person = personunit_shop(wx.Bob, wx.root_rope)
+    bob_person.add_partnerunit(exx.bob, 2)
+    bob_person.add_partnerunit(exx.sue, 1)
+    bob_person.get_partner(exx.sue).add_membership(exx.run)
+    bob_person.conpute()
+
+    # WHEN
+    run_memberships_str = get_gcal_memberships_str(bob_person, exx.run)
+
+    # THEN
+    assert run_memberships_str
+    expected_run_memberships_str = f"""{exx.run} Group
+-16.67% {exx.sue}"""
+    assert run_memberships_str == expected_run_memberships_str

--- a/src/ch19_world_kpi/test/test_person_calendar/test_gcal_day_report.py
+++ b/src/ch19_world_kpi/test/test_person_calendar/test_gcal_day_report.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from src.ch06_plan.plan import planunit_shop
+from src.ch07_person_logic.person_main import personunit_shop
+from src.ch13_time.epoch_main import add_epoch_planunit, get_default_epoch_config_dict
+from src.ch19_world_kpi.gcalendar import gcal_readable_percent, get_gcal_day_report
+from src.ref.keywords import Ch19Keywords as kw, ExampleStrs as exx
+
+
+def test_get_gcal_day_report_ReturnsObj_Scenario0_EmptyPerson():
+    # ESTABLISH
+    sue_person = personunit_shop(exx.sue, exx.a23)
+    add_epoch_planunit(sue_person)
+    apr7 = datetime(2010, 4, 7)
+    sue_person.conpute()
+
+    # WHEN
+    sue_day_report_str = get_gcal_day_report(sue_person, apr7)
+
+    # THEN
+    assert sue_day_report_str
+    assert f"Day Report for {exx.sue}" in sue_day_report_str
+    assert "Schedule Priorities" in sue_day_report_str
+    assert "All Agenda Items" in sue_day_report_str
+    assert "Partners" in sue_day_report_str
+    assert "Group" not in sue_day_report_str
+
+
+def test_get_gcal_day_report_ReturnsObj_Scenario1_NonEmptyPerson():
+    # ESTABLISH
+    sue_person = personunit_shop(exx.sue, exx.a23)
+    add_epoch_planunit(sue_person)
+    apr7 = datetime(2010, 4, 7)
+    sue_person.add_partnerunit(exx.bob, 2)
+    sue_person.add_partnerunit(exx.sue, 1)
+    casa_rope = sue_person.make_l1_rope(exx.casa)
+    clean_rope = sue_person.make_rope(casa_rope, exx.clean)
+    sue_person.add_plan(clean_rope, 1, pledge=True)
+    sue_person.get_partner(exx.sue).add_membership(exx.run)
+    sue_person.conpute()
+
+    # WHEN
+    sue_day_report_str = get_gcal_day_report(sue_person, apr7, group_title=exx.run)
+
+    # THEN
+    assert sue_day_report_str
+    assert f"Day Report for {exx.sue}" in sue_day_report_str
+    assert "Schedule Priorities" in sue_day_report_str
+    assert "All Agenda Items" in sue_day_report_str
+    assert "Partners" in sue_day_report_str
+    assert "Group" in sue_day_report_str
+    assert exx.run in sue_day_report_str

--- a/src/ch19_world_kpi/test/test_person_calendar/test_gcal_exportcsv.py
+++ b/src/ch19_world_kpi/test/test_person_calendar/test_gcal_exportcsv.py
@@ -54,8 +54,7 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario1_1AllDayPledge():
     bob_gcal_events = create_gcalendar_events_list(bob_person, day=apr7)
 
     # THEN
-    gcal_agenda_list_str = f"""1. {wx.mop_str} (100%)
-"""
+    gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (100%)"""
     description_str = "Description"
     expected_apr7str = "05/07/2010"
     expected_event_dict = {
@@ -88,10 +87,9 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario2_3AllDayPledge():
 
     # THEN
     assert len(bob_gcal_events) == 1
-    gcal_agenda_list_str = f"""1. {wx.mop_str} (50%)
+    gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (50%)
 2. {wx.scrub_str} (25%)
-3. {wx.sweep_str} (25%)
-"""
+3. {wx.sweep_str} (25%)"""
     description_str = "Description"
     start_date_str = "Start Date"
     expected_apr7str = "05/07/2010"
@@ -129,9 +127,8 @@ def test_create_gcalendar_events_list_ReturnsObj_Scenario3_OneEpoch_pledge():
     bob_gcal_events = create_gcalendar_events_list(bob_person, apr7)
 
     # THEN
-    gcal_agenda_list_str = f"""1. {wx.mop_str} (66.67%) 10:00 AM-11:30 AM
-2. {wx.sweep_str} (33.33%)
-"""
+    gcal_agenda_list_str = f"""All Agenda Items\n1. {wx.mop_str} (66.67%) 10:00 AM-11:30 AM
+2. {wx.sweep_str} (33.33%)"""
     description_str = "Description"
     start_date_str = "Start Date"
     expected_apr7str = "05/07/2010"
@@ -227,7 +224,7 @@ def test_create_gcalendar_csv_from_person_ReturnsObj_Scenario0_OneEpoch_pledge()
     expected_csv_line2 = (
         "1. mop (66.67%),05/07/2010,10:00 AM,05/07/2010,11:30 AM,False,;YY;mop;"
     )
-    expected_csv_line3 = """Pledges,05/07/2010,,05/07/2010,,True,"1. mop (66.67%) 10:00 AM-11:30 AM\n2. sweep (33.33%)\n"""
+    expected_csv_line3 = """Pledges,05/07/2010,,05/07/2010,,True,"All Agenda Items\n1. mop (66.67%) 10:00 AM-11:30 AM\n2. sweep (33.33%)"""
     assert expected_csv_line1 in bob_gcal_csv
     assert expected_csv_line2 in bob_gcal_csv
     assert expected_csv_line3 in bob_gcal_csv


### PR DESCRIPTION
## Summary by Sourcery

Add richer calendar reporting utilities and reuseable helpers for day-level epoch setup, agenda listing, partners, and group memberships, and extend tests accordingly.

New Features:
- Introduce set_day_epoch_fact helper to encapsulate day-level epoch fact computation for persons.
- Add get_gcal_memberships_str to render group membership partner lists for a given group title.
- Add get_gcal_day_report to generate a consolidated day report including schedule priorities, agenda items, partners, and optional group membership details.

Enhancements:
- Change get_inflection_points_dict to return mappings to DayEvent or None instead of PlanUnit, clarifying semantics of inflection points.
- Update agenda and calendar export strings to include an 'All Agenda Items' header and avoid trailing newlines.
- Refactor partner list formatting into create_partners_only_list_str for reuse by partners and memberships views.
- Have create_gcalendar_events_list rely on get_dayevents for epoch setup and only emit all-day pledge events when an agenda exists.
- Extend gcal_readable_percent to gracefully handle None values by treating them as zero.

Tests:
- Add unit tests for group membership calendar strings, day report output in empty and non-empty scenarios, and adjust existing agenda/export CSV tests for the new output formats.