### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch20_kpi/test/_util/test_ch20_path.py
+++ b/src/ch20_kpi/test/_util/test_ch20_path.py
@@ -8,7 +8,7 @@ from src.ch20_kpi._ref.ch20_path import (
     create_moments_dir_path,
 )
 from src.ch20_kpi.test._util.ch20_env import get_temp_dir
-from src.ref.keywords import Ch18Keywords as kw, ExampleStrs as exx
+from src.ref.keywords import Ch20Keywords as kw, ExampleStrs as exx
 
 
 def test_create_day_report_txt_path_ReturnsObj():
@@ -32,7 +32,7 @@ def test_create_day_report_txt_path_ReturnsObj():
 LINUX_OS = platform_system() == "Linux"
 
 
-def test_create_last_run_metrics_path_HasDocString():
+def test_create_day_report_txt_path_HasDocString():
     # ESTABLISH
     x_moment_mstr_dir = "moment_mstr_dir"
     moment_rope_lasso = lassounit_shop(create_rope(kw.moment_rope))

--- a/src/ch20_kpi/test/_util/test_ch20_path.py
+++ b/src/ch20_kpi/test/_util/test_ch20_path.py
@@ -29,9 +29,6 @@ def test_create_day_report_txt_path_ReturnsObj():
     assert gen_bob_day_report_txt_path == expected_bob_day_report_txt_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
 def test_create_day_report_txt_path_HasDocString():
     # ESTABLISH
     x_moment_mstr_dir = "moment_mstr_dir"
@@ -41,4 +38,4 @@ def test_create_day_report_txt_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_day_report_txt_path) == doc_str
+    assert inspect_getdoc(create_day_report_txt_path) == doc_str

--- a/src/ch21_world/test/test_output/test_gcal_day_output.py
+++ b/src/ch21_world/test/test_output/test_gcal_day_output.py
@@ -1,17 +1,20 @@
 # from datetime import datetime
-# from src.ch07_person_logic.person_main import personunit_shop
+# from os.path import exists as os_path_exists
+# from src.ch00_py.file_toolbox import open_file
 # from src.ch09_person_lesson.lasso import lassounit_shop
 # from src.ch10_person_listen.keep_tool import save_job_file
 # from src.ch13_time.epoch_main import add_epoch_planunit, get_default_epoch_config_dict
 # from src.ch14_moment.moment_main import momentunit_shop, save_moment_file
+# from src.ch20_kpi._ref.ch20_path import create_day_report_txt_path as day_report_path
 # from src.ch20_kpi.test._util.ch20_examples import (
 #     get_a23_sue_clean_example,
 #     get_ep8_sue_clean_example,
 #     get_ep8_yao_clean_example,
 # )
 # from src.ch21_world.test._util.ch21_env import get_temp_dir, temp_dir_setup
-# from src.ref.keywords import ExampleStrs as exx, Ch21Keywords as kw
 # from src.ch21_world.world import sheets_to_gcal_day_reports
+# from src.ref.keywords import Ch21Keywords as kw, ExampleStrs as exx
+
 
 # def test_get_person_gcal_day_reports_ReturnsObj_Scenario0_NoData(
 #     temp_dir_setup,
@@ -19,8 +22,6 @@
 #     # ESTABLISH
 #     mmt_mstr_dir = get_temp_dir()
 #     apr7 = datetime(2010, 4, 7)
-#     #TODO
-#     create gcal_file_path
 
 #     # WHEN
 #     sue_day_reports = sheets_to_gcal_day_reports(
@@ -34,137 +35,43 @@
 #     assert sue_day_reports == {}
 
 
-# def test_get_person_gcal_day_reports_ReturnsObj_Scenario1_Two_day_reports(
+# def test_sheets_to_gcal_day_reports_SavesFiles_Scenario0_TwoSueReports(
 #     temp_dir_setup,
 # ):
 #     # ESTABLISH
-#     sue_a23_person = get_a23_sue_clean_example()
-#     sue_ep8_person = get_ep8_sue_clean_example()
-#     epoch_config = get_default_epoch_config_dict()
-#     x_epoch_label = epoch_config.get("epoch_label")
-#     add_epoch_planunit(sue_a23_person, epoch_config)
-#     add_epoch_planunit(sue_ep8_person, epoch_config)
-#     sue_a23_person.conpute()
-#     sue_ep8_person.conpute()
-#     apr7 = datetime(2010, 4, 7)
-#     # save momentunit json
-#     mmt_mstr_dir = get_temp_dir()
-#     a23_moment = momentunit_shop(exx.a23, mmt_mstr_dir)
-#     ep8_moment = momentunit_shop(exx.ep8, mmt_mstr_dir)
-#     a23_lasso = lassounit_shop(a23_moment.moment_rope, a23_moment.knot)
-#     ep8_lasso = lassounit_shop(ep8_moment.moment_rope, ep8_moment.knot)
-#     assert a23_moment.epoch.epoch_label == x_epoch_label
-#     assert ep8_moment.epoch.epoch_label == x_epoch_label
-#     save_moment_file(a23_moment, a23_lasso)
-#     save_moment_file(ep8_moment, ep8_lasso)
-#     # save personunit json as job file
-#     save_job_file(mmt_mstr_dir, sue_a23_person)
-#     save_job_file(mmt_mstr_dir, sue_ep8_person)
-
-#     # WHEN
-#     sue_day_reports = get_person_gcal_day_reports(
-#         moment_mstr_dir=mmt_mstr_dir,
-#         person_name=exx.sue,
-#         day=apr7,
-#         focus_group_title=exx.run,
-#     )
-
-#     # THEN
-#     assert sue_day_reports
-#     assert set(sue_day_reports.keys()) == {exx.a23, exx.ep8}
-#     assert "Schedule Priorities" in sue_day_reports.get(exx.a23)
-
-
-# def test_get_person_gcal_day_reports_ReturnsObj_Scenario2_OnlySueReports(
-#     temp_dir_setup,
-# ):
-#     # ESTABLISH
+#     # TODO convert this to dataframe
 #     sue_a23_person = get_a23_sue_clean_example()
 #     sue_ep8_person = get_ep8_sue_clean_example()
 #     yao_ep8_person = get_ep8_yao_clean_example()
+#     # TODO save dataframes as sheets
 #     epoch_config = get_default_epoch_config_dict()
 #     x_epoch_label = epoch_config.get("epoch_label")
 #     add_epoch_planunit(sue_a23_person, epoch_config)
 #     add_epoch_planunit(sue_ep8_person, epoch_config)
 #     add_epoch_planunit(yao_ep8_person, epoch_config)
-#     sue_a23_person.conpute()
-#     sue_ep8_person.conpute()
-#     yao_ep8_person.conpute()
 #     apr7 = datetime(2010, 4, 7)
 #     # save momentunit json
 #     mmt_mstr_dir = get_temp_dir()
-#     a23_moment = momentunit_shop(exx.a23, mmt_mstr_dir)
-#     ep8_moment = momentunit_shop(exx.ep8, mmt_mstr_dir)
-#     a23_lasso = lassounit_shop(a23_moment.moment_rope, a23_moment.knot)
-#     ep8_lasso = lassounit_shop(ep8_moment.moment_rope, ep8_moment.knot)
-#     assert a23_moment.epoch.epoch_label == x_epoch_label
-#     assert ep8_moment.epoch.epoch_label == x_epoch_label
-#     save_moment_file(a23_moment, a23_lasso)
-#     save_moment_file(ep8_moment, ep8_lasso)
-#     # save personunit json as job file
-#     save_job_file(mmt_mstr_dir, sue_a23_person)
-#     save_job_file(mmt_mstr_dir, sue_ep8_person)
-#     save_job_file(mmt_mstr_dir, yao_ep8_person)
+#     a23_lasso = lassounit_shop(exx.a23)
+#     ep8_lasso = lassounit_shop(exx.ep8)
+#     # assert exists moment_file(a23_moment, a23_lasso)
+#     # assert exists moment_file(ep8_moment, ep8_lasso)
+#     # assert exists job_file(mmt_mstr_dir, sue_a23_person)
+#     # assert exists job_file(mmt_mstr_dir, sue_ep8_person)
+#     # assert exists job_file(mmt_mstr_dir, yao_ep8_person)
+#     sue_a23_day_report_path = day_report_path(mmt_mstr_dir, a23_lasso, exx.sue)
+#     sue_ep8_day_report_path = day_report_path(mmt_mstr_dir, ep8_lasso, exx.sue)
+#     assert not os_path_exists(sue_a23_day_report_path)
+#     assert not os_path_exists(sue_ep8_day_report_path)
 
 #     # WHEN
-#     sue_day_reports = get_person_gcal_day_reports(
-#         moment_mstr_dir=mmt_mstr_dir,
-#         person_name=exx.sue,
-#         day=apr7,
-#         focus_group_title=exx.run,
-#     )
+#     sheets_to_gcal_day_reports(moment_mstr_dir=mmt_mstr_dir)
 
 #     # THEN
-#     assert sue_day_reports
-#     assert set(sue_day_reports.keys()) == {exx.a23, exx.ep8}
-#     assert "Schedule Priorities" in sue_day_reports.get(exx.a23)
-#     assert f"Day Report for {exx.sue}" in sue_day_reports.get(exx.a23)
-#     assert f"Day Report for {exx.sue}" in sue_day_reports.get(exx.ep8)
-
-
-# # # TODO model after stance_output tests
-# # def test_get_gcal_day_report_from_personunit_ReturnsObj_Scenario0_EmptyPerson():
-# #     # ESTABLISH
-# #     sue_person = personunit_shop(exx.sue, exx.a23)
-# #     add_epoch_planunit(sue_person)
-# #     apr7 = datetime(2010, 4, 7)
-# #     sue_person.conpute()
-
-# #     # WHEN
-# #     sue_day_report_str = get_gcal_day_report_from_personunit(sue_person, apr7)
-
-# #     # THEN
-# #     assert sue_day_report_str
-# #     assert f"Day Report for {exx.sue}" in sue_day_report_str
-# #     assert "Schedule Priorities" in sue_day_report_str
-# #     assert "All Agenda Items" in sue_day_report_str
-# #     assert "Partners" in sue_day_report_str
-# #     assert "Group" not in sue_day_report_str
-
-
-# # def test_get_gcal_day_report_from_personunit_ReturnsObj_Scenario1_NonEmptyPerson():
-# #     # ESTABLISH
-# #     sue_person = personunit_shop(exx.sue, exx.a23)
-# #     add_epoch_planunit(sue_person)
-# #     apr7 = datetime(2010, 4, 7)
-# #     sue_person.add_partnerunit(exx.bob, 2)
-# #     sue_person.add_partnerunit(exx.sue, 1)
-# #     casa_rope = sue_person.make_l1_rope(exx.casa)
-# #     clean_rope = sue_person.make_rope(casa_rope, exx.clean)
-# #     sue_person.add_plan(clean_rope, 1, pledge=True)
-# #     sue_person.get_partner(exx.sue).add_membership(exx.run)
-# #     sue_person.conpute()
-
-# #     # WHEN
-# #     sue_day_report_str = get_gcal_day_report_from_personunit(
-# #         sue_person, apr7, group_title=exx.run
-# #     )
-
-# #     # THEN
-# #     assert sue_day_report_str
-# #     assert f"Day Report for {exx.sue}" in sue_day_report_str
-# #     assert "Schedule Priorities" in sue_day_report_str
-# #     assert "All Agenda Items" in sue_day_report_str
-# #     assert "Partners" in sue_day_report_str
-# #     assert "Group" in sue_day_report_str
-# #     assert exx.run in sue_day_report_str
+#     assert os_path_exists(sue_a23_day_report_path)
+#     assert os_path_exists(sue_ep8_day_report_path)
+#     sue_a23_day_report_str = open_file(sue_a23_day_report_path)
+#     sue_ep8_day_report_str = open_file(sue_ep8_day_report_path)
+#     assert "Schedule Priorities" in sue_ep8_day_report_str
+#     assert f"Day Report for {exx.sue}" in sue_a23_day_report_str
+#     assert f"Day Report for {exx.sue}" in sue_ep8_day_report_str

--- a/src/ch21_world/world.py
+++ b/src/ch21_world/world.py
@@ -41,6 +41,20 @@ from src.ch20_kpi.kpi_mstr import create_calendar_markdown_files, populate_kpi_b
 from src.ch21_world._ref.ch21_semantic_types import WorldName
 
 
+def create_stances(
+    world_dir: str,
+    output_dir: str,
+    world_name: str,
+    moment_mstr_dir: str,
+    prettify_excel_bool=True,
+):
+    # TODO why is create_stance0001_file not drawing from world db instead of files?
+    # it should be the database because that's the end of the core pipeline so it should
+    # be the source of truth.
+    create_stance0001_file(world_dir, output_dir, world_name, prettify_excel_bool)
+    create_calendar_markdown_files(moment_mstr_dir, output_dir)
+
+
 def sheets_input_to_lynx_with_cursor(
     cursor: sqlite3_Cursor, input_dir: str, moment_mstr_dir: str
 ):
@@ -79,20 +93,6 @@ def sheets_input_to_lynx_with_cursor(
     etl_moment_json_partner_nets_to_moment_partner_nets_table(cursor, moment_mstr_dir)
     populate_kpi_bundle(cursor)
     create_last_run_metrics_json(cursor, moment_mstr_dir)
-
-
-def create_stances(
-    world_dir: str,
-    output_dir: str,
-    world_name: str,
-    moment_mstr_dir: str,
-    prettify_excel_bool=True,
-):
-    # TODO why is create_stance0001_file not drawing from world db instead of files?
-    # it should be the database because that's the end of the core pipeline so it should
-    # be the source of truth.
-    create_stance0001_file(world_dir, output_dir, world_name, prettify_excel_bool)
-    create_calendar_markdown_files(moment_mstr_dir, output_dir)
 
 
 def sheets_input_to_lynx_mstr(world_db_path: str, input_dir: str, moment_mstr_dir: str):
@@ -168,3 +168,7 @@ def worlddir_shop(
     if not x_worlddir._input_dir:
         x_worlddir.set_input_dir(create_path(x_worlddir._world_dir, "input"))
     return x_worlddir
+
+
+def sheets_to_gcal_day_reports():
+    pass


### PR DESCRIPTION
## Summary by Sourcery

Add scaffolding for generating gcal day report files and tighten path utility tests.

Enhancements:
- Introduce a stub sheets_to_gcal_day_reports entry point in the world module for future gcal day report generation.
- Adjust keyword imports in KPI path tests to use chapter 20 keywords.

Tests:
- Add a commented-out test outlining expected behavior for sheets_to_gcal_day_reports creating per-person day report files.
- Strengthen create_day_report_txt_path docstring test to always verify the exact expected docstring and rename the test accordingly.