### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch00_py/test/_util/test_ch00_path.py
+++ b/src/ch00_py/test/_util/test_ch00_path.py
@@ -25,7 +25,7 @@ def test_create_src_example_strs_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
-@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_src_example_strs_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -52,7 +52,7 @@ def test_create_src_keywords_main_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
-@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_src_keywords_main_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -79,7 +79,7 @@ def test_create_keywords_classes_file_path_ReturnsObj():
     assert keywords_class_file_path == expected_keywords_file_path
 
 
-@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keywords_classes_file_path_HasDocString():
     # ESTABLISH
     doc_str = create_keywords_classes_file_path("src")

--- a/src/ch00_py/test/_util/test_ch00_path.py
+++ b/src/ch00_py/test/_util/test_ch00_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py._ref.ch00_path import (
     create_keywords_classes_file_path,
     create_src_example_strs_path,
@@ -7,8 +8,6 @@ from src.ch00_py._ref.ch00_path import (
 )
 from src.ch00_py.file_toolbox import create_path, get_json_filename
 from src.ch00_py.test._util.ch00_env import get_temp_dir
-
-LINUX_OS = platform_system() == "Linux"
 
 
 def test_create_src_example_strs_path_ReturnsObj():
@@ -26,6 +25,7 @@ def test_create_src_example_strs_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
 def test_create_src_example_strs_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -34,7 +34,7 @@ def test_create_src_example_strs_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_src_example_strs_path) == doc_str
+    assert inspect_getdoc(create_src_example_strs_path) == doc_str
 
 
 def test_create_src_keywords_main_path_ReturnsObj():
@@ -52,6 +52,7 @@ def test_create_src_keywords_main_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
 def test_create_src_keywords_main_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -60,7 +61,7 @@ def test_create_src_keywords_main_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_src_keywords_main_path) == doc_str
+    assert inspect_getdoc(create_src_keywords_main_path) == doc_str
 
 
 def test_create_keywords_classes_file_path_ReturnsObj():
@@ -78,10 +79,11 @@ def test_create_keywords_classes_file_path_ReturnsObj():
     assert keywords_class_file_path == expected_keywords_file_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="Skipped on Linux")
 def test_create_keywords_classes_file_path_HasDocString():
     # ESTABLISH
     doc_str = create_keywords_classes_file_path("src")
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keywords_classes_file_path) == doc_str
+    assert inspect_getdoc(create_keywords_classes_file_path) == doc_str

--- a/src/ch00_py/test/dict/test__file_.py
+++ b/src/ch00_py/test/dict/test__file_.py
@@ -1,7 +1,7 @@
 from os.path import exists as os_path_exist, join as os_path_join
 from pathlib import Path as pathlib_Path
 from platform import system as platform_system
-from pytest import raises as pytest_raises
+from pytest import mark as pytest_mark, raises as pytest_raises
 from src.ch00_py.dict_toolbox import get_dict_from_json
 from src.ch00_py.file_toolbox import (
     can_usser_edit_paths,
@@ -526,17 +526,14 @@ def test_create_directory_path_ReturnsObj():
     assert kern_path == create_path(elpaso_path, kern_str)
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_is_path_valid_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     assert is_path_valid("run")
     assert is_path_valid("run/trail")
     assert is_path_valid("run/,trail")
-    assert (
-        platform_system() == "Windows" and is_path_valid("trail?") is False
-    ) or platform_system() == "Linux"
-    assert (
-        platform_system() == "Windows" and is_path_valid("run/trail?") is False
-    ) or platform_system() == "Linux"
+    assert is_path_valid("trail?") is False
+    assert is_path_valid("run/trail?") is False
     assert is_path_valid("run//trail////")
 
 
@@ -546,14 +543,12 @@ def test_can_usser_edit_paths_ReturnsObj():
     assert can_usser_edit_paths()
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_is_path_existent_or_creatable_ReturnsObj():
     # ESTABLISH / WHEN / THEN
     """I am not able to test. For now make sure it runs."""
     assert is_path_existent_or_creatable("run")
-    assert (
-        platform_system() == "Windows"
-        and is_path_existent_or_creatable("run/trail?") is False
-    ) or platform_system() == "Linux"
+    assert is_path_existent_or_creatable("run/trail?") is False
     assert is_path_existent_or_creatable("run///trail")
 
 

--- a/src/ch04_rope/test/test_rope_core.py
+++ b/src/ch04_rope/test/test_rope_core.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from platform import system as platform_system
-from pytest import raises as pytest_raises
+from pytest import mark as pytest_mark, raises as pytest_raises
 from src.ch04_rope._ref.ch04_semantic_types import default_knot_if_None
 from src.ch04_rope.rope import (
     RopeTerm,
@@ -597,6 +597,7 @@ def test_validate_labelterm_Scenario1_RaisesErrorWhenLabelTerm():
     assert str(excinfo.value) == assertion_failure_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario0_simple_knot():
     # ESTABLISH
     comma_str = ","
@@ -604,12 +605,10 @@ def test_rope_is_valid_dir_path_ReturnsObj_Scenario0_simple_knot():
     assert rope_is_valid_dir_path(",run,", knot=comma_str)
     assert rope_is_valid_dir_path(",run,sport,", knot=comma_str)
     print(f"{platform_system()=}")
-    sport_question_valid_bool = rope_is_valid_dir_path("run,sport?,", comma_str)
-    assert (
-        platform_system() == "Windows" and sport_question_valid_bool is False
-    ) or platform_system() == "Linux"
+    assert not rope_is_valid_dir_path("run,sport?,", comma_str)
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario1_complicated_knot():
     # ESTABLISH
     question_str = "?"
@@ -626,10 +625,7 @@ def test_rope_is_valid_dir_path_ReturnsObj_Scenario1_complicated_knot():
     assert rope_is_valid_dir_path(sport_rope, knot=question_str)
     assert rope_is_valid_dir_path(run_rope, knot=question_str)
     assert rope_is_valid_dir_path(lap_rope, knot=question_str)
-    assert (
-        platform_system() == "Windows"
-        and rope_is_valid_dir_path(lap_rope, knot=",") is False
-    ) or platform_system() == "Linux"
+    assert rope_is_valid_dir_path(lap_rope, knot=",") is False
 
 
 def test_rope_is_valid_dir_path_ReturnsObj_Scenario2_WhereSlashNotknotEdgeSituations():

--- a/src/ch09_person_lesson/test/_util/test_ch09_path.py
+++ b/src/ch09_person_lesson/test/_util/test_ch09_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch04_rope.rope import create_rope
 from src.ch09_person_lesson._ref.ch09_path import (
@@ -161,27 +162,27 @@ def test_create_job_path_ReturnsObj():
     assert gen_a23_e3_person_path == expected_a23_bob_job_json_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moments_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_moments_dir_path("moment_mstr_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    # TODO see if all "LINUX_OS or inspect_getdoc" can be gotten rid of
-    assert LINUX_OS or inspect_getdoc(create_moments_dir_path) == doc_str
+    # TODO see if all " inspect_getdoc" can be gotten rid of
+    assert inspect_getdoc(create_moments_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
     doc_str = create_moment_dir_path("moment_mstr_dir", x_moment_lasso)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_dir_path) == doc_str
+    assert inspect_getdoc(create_moment_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_json_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -191,9 +192,10 @@ def test_create_moment_json_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_json_path) == doc_str
+    assert inspect_getdoc(create_moment_json_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_persons_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -203,9 +205,10 @@ def test_create_moment_persons_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_persons_dir_path) == doc_str
+    assert inspect_getdoc(create_moment_persons_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_person_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -216,9 +219,10 @@ def test_create_person_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_person_dir_path) == doc_str
+    assert inspect_getdoc(create_person_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_atoms_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -229,9 +233,10 @@ def test_create_atoms_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_atoms_dir_path) == doc_str
+    assert inspect_getdoc(create_atoms_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_lessons_dir_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -242,9 +247,10 @@ def test_create_lessons_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_lessons_dir_path) == doc_str
+    assert inspect_getdoc(create_lessons_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_gut_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -258,9 +264,10 @@ def test_create_gut_path_HasDocString():
     print(f"{doc_str=}")
     print(f"{inspect_getdoc(create_gut_path)=}")
     print(inspect_getdoc(create_gut_path))
-    assert LINUX_OS or inspect_getdoc(create_gut_path) == doc_str
+    assert inspect_getdoc(create_gut_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_job_path_HasDocString():
     # ESTABLISH
     x_moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -271,4 +278,4 @@ def test_create_job_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_job_path) == doc_str
+    assert inspect_getdoc(create_job_path) == doc_str

--- a/src/ch10_person_listen/test/_util/test_ch10_path.py
+++ b/src/ch10_person_listen/test/_util/test_ch10_path.py
@@ -1,6 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
-from pytest import raises as pytest_raises
+from pytest import mark as pytest_mark, raises as pytest_raises
 from src.ch00_py.file_toolbox import create_path, get_json_filename
 from src.ch04_rope.rope import create_rope, create_rope_from_labels
 from src.ch10_person_listen._ref.ch10_path import (
@@ -16,8 +16,6 @@ from src.ch10_person_listen._ref.ch10_path import (
 )
 from src.ch10_person_listen.test._util.ch10_env import get_temp_dir
 from src.ref.keywords import Ch10Keywords as kw, ExampleStrs as exx
-
-LINUX_OS = platform_system() == "Linux"
 
 
 def test_treasury_filename_ReturnsObj():
@@ -292,6 +290,7 @@ def test_create_treasury_db_path_ReturnsObj() -> None:
     assert gen_keep_dutys_path == expected_keep_dutys_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keeps_dir_path_HasDocString():
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -302,9 +301,10 @@ def test_create_keeps_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keeps_dir_path) == doc_str
+    assert inspect_getdoc(create_keeps_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_rope_path_HasDocString() -> None:
     # ESTABLISH
     level1_label_str = "level1_label"
@@ -319,9 +319,10 @@ def test_create_keep_rope_path_HasDocString() -> None:
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_rope_path) == doc_str
+    assert inspect_getdoc(create_keep_rope_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_dutys_path_HasDocString() -> None:
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -335,9 +336,10 @@ def test_create_keep_dutys_path_HasDocString() -> None:
     expected_doc_str = f"Returns path: {expected_doc_str}"
     print(f"{expected_doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_dutys_path) == expected_doc_str
+    assert inspect_getdoc(create_keep_dutys_path) == expected_doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_duty_path_HasDocString() -> None:
     # ESTABLISH
     duty_person_str = "duty_person"
@@ -353,9 +355,10 @@ def test_create_keep_duty_path_HasDocString() -> None:
     expected_doc_str = f"Returns path: {expected_doc_str}"
     print(f"{expected_doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_duty_path) == expected_doc_str
+    assert inspect_getdoc(create_keep_duty_path) == expected_doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_grades_path_HasDocString() -> None:
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -370,9 +373,10 @@ def test_create_keep_grades_path_HasDocString() -> None:
     print(f"                             {doc_str=}")
     print(f"{inspect_getdoc(create_keep_grades_path)=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_grades_path) == doc_str
+    assert inspect_getdoc(create_keep_grades_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_grade_path_HasDocString() -> None:
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -388,9 +392,10 @@ def test_create_keep_grade_path_HasDocString() -> None:
     print(f"{doc_str=}")
     print(f"{inspect_getdoc(create_keep_grade_path)=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_grade_path) == doc_str
+    assert inspect_getdoc(create_keep_grade_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_keep_visions_path_HasDocString() -> None:
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -404,9 +409,10 @@ def test_create_keep_visions_path_HasDocString() -> None:
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_keep_visions_path) == doc_str
+    assert inspect_getdoc(create_keep_visions_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_treasury_db_path_HasDocString() -> None:
     # ESTABLISH
     x_moment_rope = create_rope(kw.moment_rope)
@@ -420,4 +426,4 @@ def test_create_treasury_db_path_HasDocString() -> None:
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_treasury_db_path) == doc_str
+    assert inspect_getdoc(create_treasury_db_path) == doc_str

--- a/src/ch11_bud/test/_util/test_ch11_path.py
+++ b/src/ch11_bud/test/_util/test_ch11_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch04_rope.rope import create_rope
 from src.ch09_person_lesson.lasso import lassounit_shop
@@ -336,9 +337,7 @@ def test_create_spark_expressed_lesson_path_ReturnsObj():
     assert gen_a23_e3_person_path == expected_a23_bob_e3_expressed_lesson_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_buds_dir_path_HasDocString():
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
     # ESTABLISH
@@ -349,9 +348,10 @@ def test_create_buds_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_buds_dir_path) == doc_str
+    assert inspect_getdoc(create_buds_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_bud_dir_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -364,9 +364,10 @@ def test_create_bud_dir_path_HasDocString():
     doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_bud_dir_path) == doc_str
+    assert inspect_getdoc(create_bud_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_cell_dir_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -381,9 +382,10 @@ def test_create_cell_dir_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_dir_path) == doc_str
+    assert inspect_getdoc(create_cell_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_cell_json_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -398,9 +400,10 @@ def test_create_cell_json_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_cell_json_path) == doc_str
+    assert inspect_getdoc(create_cell_json_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_cell_partner_mandate_ledger_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -415,11 +418,10 @@ def test_create_cell_partner_mandate_ledger_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert (
-        LINUX_OS or inspect_getdoc(create_cell_partner_mandate_ledger_path) == doc_str
-    )
+    assert inspect_getdoc(create_cell_partner_mandate_ledger_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_budunit_json_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -432,9 +434,10 @@ def test_create_budunit_json_path_HasDocString():
     doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_budunit_json_path) == doc_str
+    assert inspect_getdoc(create_budunit_json_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_persontime_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -447,9 +450,10 @@ def test_create_persontime_path_HasDocString():
     doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_persontime_path) == doc_str
+    assert inspect_getdoc(create_persontime_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_person_spark_dir_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -461,9 +465,10 @@ def test_create_person_spark_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_person_spark_dir_path) == doc_str
+    assert inspect_getdoc(create_person_spark_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_person_spark_csv_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -476,9 +481,10 @@ def test_create_person_spark_csv_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_person_spark_csv_path) == doc_str
+    assert inspect_getdoc(create_person_spark_csv_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_personspark_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -490,9 +496,10 @@ def test_create_personspark_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_personspark_path) == doc_str
+    assert inspect_getdoc(create_personspark_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_spark_all_lesson_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -504,9 +511,10 @@ def test_create_spark_all_lesson_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_spark_all_lesson_path) == doc_str
+    assert inspect_getdoc(create_spark_all_lesson_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_spark_expressed_lesson_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
@@ -518,4 +526,4 @@ def test_create_spark_expressed_lesson_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_spark_expressed_lesson_path) == doc_str
+    assert inspect_getdoc(create_spark_expressed_lesson_path) == doc_str

--- a/src/ch14_moment/test/_util/test_ch14_path.py
+++ b/src/ch14_moment/test/_util/test_ch14_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch04_rope.rope import create_rope
 from src.ch09_person_lesson.lasso import lassounit_shop
@@ -33,9 +34,7 @@ def test_create_bud_partner_mandate_ledger_path_ReturnsObj():
     assert gen_bud_path == expected_bud_path_dir
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_bud_partner_mandate_ledger_path_HasDocString():
     # ESTABLISH
     doc_str = create_bud_partner_mandate_ledger_path(
@@ -47,4 +46,4 @@ def test_create_bud_partner_mandate_ledger_path_HasDocString():
     doc_str = doc_str.replace("buds\\bud_time", "buds\n\\bud_time")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_bud_partner_mandate_ledger_path) == doc_str
+    assert inspect_getdoc(create_bud_partner_mandate_ledger_path) == doc_str

--- a/src/ch18_etl_config/test/_util/test_ch18_path.py
+++ b/src/ch18_etl_config/test/_util/test_ch18_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch04_rope.rope import create_rope
 from src.ch09_person_lesson.lasso import lassounit_shop
@@ -44,12 +45,13 @@ def test_create_moment_mstr_path_ReturnsObj():
     assert gen_last_run_metrics_path == expected_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_mstr_path_HasDocString():
     # ESTABLISH
     doc_str = create_moment_mstr_path(world_dir="world_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_mstr_path) == doc_str
+    assert inspect_getdoc(create_moment_mstr_path) == doc_str
 
 
 def test_create_last_run_metrics_path_ReturnsObj():
@@ -101,25 +103,25 @@ def test_create_stance0001_path_ReturnsObj():
     assert gen_stance0001_xlsx_path == expected_stance000001_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_last_run_metrics_path_HasDocString():
     # ESTABLISH
     doc_str = create_last_run_metrics_path("world_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_last_run_metrics_path) == doc_str
+    assert inspect_getdoc(create_last_run_metrics_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_stances_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_stances_dir_path(moment_mstr_dir="moment_mstr_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_stances_dir_path) == doc_str
+    assert inspect_getdoc(create_stances_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_stances_person_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_stances_person_dir_path(
@@ -127,15 +129,16 @@ def test_create_stances_person_dir_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_stances_person_dir_path) == doc_str
+    assert inspect_getdoc(create_stances_person_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_stance0001_path_HasDocString():
     # ESTABLISH
     doc_str = create_stance0001_path(output_dir="output_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_stance0001_path) == doc_str
+    assert inspect_getdoc(create_stance0001_path) == doc_str
 
 
 def test_create_moment_ote1_csv_path_ReturnsObj():
@@ -180,27 +183,30 @@ def test_create_world_db_path_ReturnsObj():
     assert gen_world_db_path == expected_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_ote1_csv_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
     doc_str = create_moment_ote1_csv_path("moment_mstr_dir", moment_lasso)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_ote1_csv_path) == doc_str
+    assert inspect_getdoc(create_moment_ote1_csv_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_ote1_json_path_HasDocString():
     # ESTABLISH
     moment_lasso = lassounit_shop(create_rope(kw.moment_rope))
     doc_str = create_moment_ote1_json_path("moment_mstr_dir", moment_lasso)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_ote1_json_path) == doc_str
+    assert inspect_getdoc(create_moment_ote1_json_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_world_db_path_HasDocString():
     # ESTABLISH
     doc_str = create_world_db_path("moment_mstr_dir")
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_world_db_path) == doc_str
+    assert inspect_getdoc(create_world_db_path) == doc_str

--- a/src/ch20_kpi/gcalendar.py
+++ b/src/ch20_kpi/gcalendar.py
@@ -345,7 +345,7 @@ def get_person_gcal_day_reports(
     person_name: PersonName,
     day: datetime,
     focus_group_title: GroupTitle = None,
-) -> dict[PersonName, dict["day_report":str, "file_path":str]]:
+) -> dict[PersonName, dict[str, str]]:
     day_reports = {}
     moments_dir = create_moments_dir_path(moment_mstr_dir)
     for moment_label in get_level1_dirs(moments_dir):

--- a/src/ch20_kpi/test/_util/test_ch20_path.py
+++ b/src/ch20_kpi/test/_util/test_ch20_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch04_rope.rope import create_rope
 from src.ch09_person_lesson.lasso import lassounit_shop
@@ -29,9 +30,7 @@ def test_create_day_report_txt_path_ReturnsObj():
     assert gen_bob_day_report_txt_path == expected_bob_day_report_txt_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_day_report_txt_path_HasDocString():
     # ESTABLISH
     x_moment_mstr_dir = "moment_mstr_dir"
@@ -41,4 +40,4 @@ def test_create_day_report_txt_path_HasDocString():
     )
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_day_report_txt_path) == doc_str
+    assert inspect_getdoc(create_day_report_txt_path) == doc_str

--- a/src/ch22_lobby/test/_util/test_ch22_path.py
+++ b/src/ch22_lobby/test/_util/test_ch22_path.py
@@ -1,5 +1,6 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path
 from src.ch22_lobby._ref.ch22_path import (
     LobbyID,
@@ -65,15 +66,13 @@ def test_create_moment_mstr_dir_path_ReturnsObj():
     assert gen_m23_dir_path == expected_m23_path
 
 
-LINUX_OS = platform_system() == "Linux"
-
-
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_lobby_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_lobby_dir_path(kw.lobby_mstr_dir, kw.lobby_id)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_lobby_dir_path) == doc_str
+    assert inspect_getdoc(create_lobby_dir_path) == doc_str
 
 
 def test_create_world_dir_path_HasDocString():
@@ -81,7 +80,7 @@ def test_create_world_dir_path_HasDocString():
     doc_str = create_world_dir_path(kw.lobby_mstr_dir, kw.lobby_id, kw.world_name)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_world_dir_path) == doc_str
+    assert inspect_getdoc(create_world_dir_path) == doc_str
 
 
 def test_create_moment_mstr_dir_path_HasDocString():
@@ -89,4 +88,4 @@ def test_create_moment_mstr_dir_path_HasDocString():
     doc_str = create_moment_mstr_dir_path(kw.lobby_mstr_dir, kw.lobby_id, kw.world_name)
     doc_str = f"Returns path: {doc_str}"
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_moment_mstr_dir_path) == doc_str
+    assert inspect_getdoc(create_moment_mstr_dir_path) == doc_str

--- a/src/ch22_lobby/test/_util/test_ch22_path.py
+++ b/src/ch22_lobby/test/_util/test_ch22_path.py
@@ -75,6 +75,7 @@ def test_create_lobby_dir_path_HasDocString():
     assert inspect_getdoc(create_lobby_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_world_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_world_dir_path(kw.lobby_mstr_dir, kw.lobby_id, kw.world_name)
@@ -83,6 +84,7 @@ def test_create_world_dir_path_HasDocString():
     assert inspect_getdoc(create_world_dir_path) == doc_str
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_moment_mstr_dir_path_HasDocString():
     # ESTABLISH
     doc_str = create_moment_mstr_dir_path(kw.lobby_mstr_dir, kw.lobby_id, kw.world_name)

--- a/src/ch98_docs_builder/test/_util/test_ch98_path.py
+++ b/src/ch98_docs_builder/test/_util/test_ch98_path.py
@@ -1,13 +1,12 @@
 from inspect import getdoc as inspect_getdoc
 from platform import system as platform_system
+from pytest import mark as pytest_mark
 from src.ch00_py.file_toolbox import create_path, get_json_filename
 from src.ch98_docs_builder._ref.ch98_path import (
     create_chapter_ref_path,
     create_src_keywords_description_path,
 )
 from src.ch98_docs_builder.test._util.ch98_env import get_temp_dir
-
-LINUX_OS = platform_system() == "Linux"
 
 
 def test_create_src_keywords_description_path_ReturnsObj():
@@ -26,6 +25,7 @@ def test_create_src_keywords_description_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_src_keywords_description_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -34,7 +34,7 @@ def test_create_src_keywords_description_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_src_keywords_description_path) == doc_str
+    assert inspect_getdoc(create_src_keywords_description_path) == doc_str
 
 
 def test_create_chapter_ref_path_ReturnsObj():
@@ -54,6 +54,7 @@ def test_create_chapter_ref_path_ReturnsObj():
     assert keywords_class_file_path == expected_file_path
 
 
+@pytest_mark.skipif(platform_system() == "Linux", reason="conflict in file path str")
 def test_create_chapter_ref_path_HasDocString():
     # ESTABLISH
     src_dir = "src"
@@ -63,4 +64,4 @@ def test_create_chapter_ref_path_HasDocString():
     doc_str = f"Returns path: {doc_str}"
     print(f"{doc_str=}")
     # WHEN / THEN
-    assert LINUX_OS or inspect_getdoc(create_chapter_ref_path) == doc_str
+    assert inspect_getdoc(create_chapter_ref_path) == doc_str


### PR DESCRIPTION
## Summary by Sourcery

Skip path-related docstring and path-validation tests on Linux and simplify their assertions to be platform-independent, while correcting a type annotation for Google Calendar KPI day reports.

Enhancements:
- Simplify the return type annotation of get_person_gcal_day_reports to a standard nested dict of strings.

Tests:
- Skip docstring and path-validation tests on Linux across multiple chapters to avoid platform-specific path string conflicts.
- Tighten path validation expectations to always treat certain characters as invalid regardless of platform.
- Remove Linux-specific conditionals in tests so remaining assertions are platform-agnostic.