### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch30_etl_app/etl_gui_main.py
+++ b/src/ch30_etl_app/etl_gui_main.py
@@ -11,7 +11,7 @@ To integrate your CLI logic, replace the `create_today_punchs()` call inside
 `_run()` with your actual ETL function / subprocess call.
 """
 
-from os import startfile as os_startfile
+from os import startfile
 from os.path import isdir as os_path_isdir
 from platform import system as platform_system
 from src.ch21_world.world import create_today_punchs
@@ -79,10 +79,15 @@ class OptionTable(tk.Frame):
 def open_directory(path: str) -> None:
     """Open a folder in the OS file explorer."""
     system = platform_system()
+
     if system == "Windows":
-        os_startfile(path)  # noqa: S606
+        from os import startfile  # import only when needed
+
+        startfile(path)  # noqa: S606
+
     elif system == "Darwin":
         subprocess_Popen(["open", path])
+
     else:
         subprocess_Popen(["xdg-open", path])
 
@@ -140,6 +145,45 @@ class ETLApp(tk.Tk):
             tkinter_messagebox.showwarning("Invalid directory", invalid_dir_str)
 
     # ── UI construction ────────────────────────
+    def get_main_rows_config(self) -> dict:
+        return {
+            "0": {
+                "row_type": "text",
+                "title": "PERSON NAME",
+                "var": self._person,
+                "required": True,
+                "tip": "e.g. 'Emmanuel'",
+            },
+            "1": {
+                "row_type": "dir",
+                "title": "WORKING DIR",
+                "var": self._working,
+                "required": True,
+                "tip": "Root directory for the ETL process",
+            },
+            "2": {
+                "row_type": "dir",
+                "title": "BELIEFS_DIR",
+                "var": self._b_src_dir,
+                "required": True,
+                "tip": "Source of Beliefs. Non-sparked Ideas.",
+            },
+            "3": {
+                "row_type": "dir",
+                "title": "IDEAS_DIR  ",
+                "var": self._i_src_dir,
+                "required": True,
+                "tip": "Source of Ideas files. Beliefs that have been sparked.",
+            },
+            "4": {
+                "row_type": "dir",
+                "title": "OUTPUT DIR ",
+                "var": self._output,
+                "required": True,
+                "tip": "Destination for results (opened on finish)",
+            },
+        }
+
     def _build_ui(self):
         # ── header bar ──────────────────────────
         ax = get_app_glb_attrs()
@@ -152,11 +196,7 @@ class ETLApp(tk.Tk):
         tk.Label(
             title_frame,
             text="Keg Listening App#1",
-            font=(
-                ("Courier New", 17, "bold")
-                if platform_system() == "Windows"
-                else ("Menlo", 16, "bold")
-            ),
+            font=ax.platform_font,
             bg=ax.bg,
             fg=ax.accent,
             anchor="w",
@@ -177,22 +217,7 @@ class ETLApp(tk.Tk):
         # ── directory pickers ───────────────────
         card = tk.Frame(self, bg=ax.bg_card, bd=0, padx=24, pady=20)
         card.pack(fill="x", padx=28, pady=(16, 0))
-
-        p_title = "PERSON NAME"
-        w_title = "WORKING DIR"
-        b_title = "BELIEFS_DIR"
-        i_title = "IDEAS_DIR  "
-        o_title = "OUTPUT DIR "
-        person_tip = "e.g. 'Emmanuel'"
-        self._text_row(card, 0, p_title, self._person, required=True, tip=person_tip)
-        work_tip = "Root directory for the ETL process"
-        self._dir_row(card, 1, w_title, self._working, required=True, tip=work_tip)
-        b_tip = "Source of Beliefs. Non-sparked Ideas."
-        self._dir_row(card, 2, b_title, self._b_src_dir, required=True, tip=b_tip)
-        ideas_tip = "Source of Ideas files. Beliefs that have been sparked."
-        self._dir_row(card, 3, i_title, self._i_src_dir, required=True, tip=ideas_tip)
-        output_tip = "Destination for results (opened on finish)"
-        self._dir_row(card, 4, o_title, self._output, required=True, tip=output_tip)
+        self._create_dir_rows(card)
 
         # ── run button ──────────────────────────
         btn_frame = tk.Frame(self, bg=ax.bg, pady=22)
@@ -201,11 +226,7 @@ class ETLApp(tk.Tk):
         self._run_btn = tk.Button(
             btn_frame,
             text="▶  CREATE DAILY AGENDA",
-            font=(
-                ("Courier New", 11, "bold")
-                if platform_system() == "Windows"
-                else ("Menlo", 11, "bold")
-            ),
+            font=ax.platform_font,
             bg=ax.accent,
             fg=ax.fg_black,
             activebackground=ax.btn_active,
@@ -243,6 +264,19 @@ class ETLApp(tk.Tk):
         status_bar.pack(fill="x", side="bottom")
 
         tk.Frame(self, bg=ax.border, height=1).pack(fill="x", side="bottom")
+
+    def _create_dir_rows(self, card):
+        for row_number, row_dict in self.get_main_rows_config().items():
+            row_int = (int(row_number),)
+            title = (row_dict.get("title"),)
+            var = (row_dict.get("var"),)
+            req = (row_dict.get("required"),)
+            tip = (row_dict.get("tip"),)
+
+            if row_dict.get("row_type") == "text":
+                self._text_row(card, row_int, title, var, required=req, tip=tip)
+            elif row_dict.get("row_type") == "dir":
+                self._dir_row(card, row_int, title, var, required=req, tip=tip)
 
     def _dir_row(self, parent, row, label, var, *, required, tip):
         """Render one label + entry + browse button row."""
@@ -286,7 +320,7 @@ class ETLApp(tk.Tk):
             bg=ax.border,
             fg=ax.fg,
             activebackground=ax.accent,
-            activeforeground="#0d0d10",
+            activeforeground=ax.fg_black,
             relief="flat",
             bd=0,
             padx=10,
@@ -301,7 +335,7 @@ class ETLApp(tk.Tk):
             bg=ax.border,
             fg=ax.fg,
             activebackground=ax.accent,
-            activeforeground="#0d0d10",
+            activeforeground=ax.fg_black,
             relief="flat",
             bd=0,
             padx=10,

--- a/src/ch30_etl_app/etl_gui_main.py
+++ b/src/ch30_etl_app/etl_gui_main.py
@@ -19,6 +19,7 @@ from src.ch30_etl_app.etl_gui_tool import (
     get_app_default_dir,
     get_app_default_person_name,
     get_app_default_world_name,
+    get_app_glb_attrs,
     get_option_table_options,
     get_workspace_dirs,
 )
@@ -29,17 +30,6 @@ from tkinter import (
     messagebox as tkinter_messagebox,
     ttk as tkinter_ttk,
 )
-
-MONO = ("Courier New", 9) if platform_system() == "Windows" else ("Menlo", 10)
-BG = "#1a1a1f"
-BG_CARD = "#22222a"
-BORDER = "#33333d"
-ACCENT = "#e8c547"  # amber — classic ETL/data pipeline energy
-ACCENT_DIM = "#b89a2f"
-FG = "#e4e4e8"
-FG_DIM = "#7a7a88"
-ENTRY_BG = "#13131a"
-BTN_ACTIVE = "#f0d060"
 
 
 class OptionTable(tk.Frame):
@@ -105,14 +95,15 @@ class ETLApp(tk.Tk):
         super().__init__()
         self.title("Listening using Keg2 — ETL Launcher")
         self.resizable(False, False)
-        self.configure(bg=BG)
+        ax = get_app_glb_attrs()
+        self.configure(bg=ax.bg)
 
         # Set a reasonable minimum size and centre on screen
         self.update_idletasks()
-        w, h = 560, 500
-        x = (self.winfo_screenwidth() - w) // 2
-        y = (self.winfo_screenheight() - h) // 2
-        self.geometry(f"{w}x{h+120}+{x}+{y}")
+        app_width, app_height = 640, 500
+        x = (self.winfo_screenwidth() - app_width) // 2
+        y = (self.winfo_screenheight() - app_height) // 2
+        self.geometry(f"{app_width}x{app_height+120}+{x}+{y}")
 
         # String vars ─ empty string = "not set" (optional dirs stay None)
         self._person = tk.StringVar()
@@ -140,13 +131,22 @@ class ETLApp(tk.Tk):
         for key, var in vars_map.items():
             var.set(defaults[key])
 
+    def _open_dir(self, var: tk.StringVar):
+        path = var.get().strip()
+        if os_path_isdir(path):
+            open_directory(path)
+        else:
+            invalid_dir_str = f"Not a valid directory:\n{path}"
+            tkinter_messagebox.showwarning("Invalid directory", invalid_dir_str)
+
     # ── UI construction ────────────────────────
     def _build_ui(self):
         # ── header bar ──────────────────────────
-        header = tk.Frame(self, bg=ACCENT, height=4)
+        ax = get_app_glb_attrs()
+        header = tk.Frame(self, bg=ax.accent, height=4)
         header.pack(fill="x")
 
-        title_frame = tk.Frame(self, bg=BG, pady=18)
+        title_frame = tk.Frame(self, bg=ax.bg, pady=18)
         title_frame.pack(fill="x", padx=28)
 
         tk.Label(
@@ -157,33 +157,33 @@ class ETLApp(tk.Tk):
                 if platform_system() == "Windows"
                 else ("Menlo", 16, "bold")
             ),
-            bg=BG,
-            fg=ACCENT,
+            bg=ax.bg,
+            fg=ax.accent,
             anchor="w",
         ).pack(side="left")
 
         tk.Label(
             title_frame,
             text="excel files → db → daily agendas",
-            font=MONO,
-            bg=BG,
-            fg=FG_DIM,
+            font=ax.mono,
+            bg=ax.bg,
+            fg=ax.fg_dim,
             anchor="e",
         ).pack(side="right", pady=(4, 0))
 
         # ── divider ─────────────────────────────
-        tk.Frame(self, bg=BORDER, height=1).pack(fill="x", padx=28)
+        tk.Frame(self, bg=ax.border, height=1).pack(fill="x", padx=28)
 
         # ── directory pickers ───────────────────
-        card = tk.Frame(self, bg=BG_CARD, bd=0, padx=24, pady=20)
+        card = tk.Frame(self, bg=ax.bg_card, bd=0, padx=24, pady=20)
         card.pack(fill="x", padx=28, pady=(16, 0))
 
-        p_title = "PERSON NAM8"
+        p_title = "PERSON NAME"
         w_title = "WORKING DIR"
         b_title = "BELIEFS_DIR"
         i_title = "IDEAS_DIR  "
         o_title = "OUTPUT DIR "
-        person_tip = "e.g. 'Big Steve'"
+        person_tip = "e.g. 'Emmanuel'"
         self._text_row(card, 0, p_title, self._person, required=True, tip=person_tip)
         work_tip = "Root directory for the ETL process"
         self._dir_row(card, 1, w_title, self._working, required=True, tip=work_tip)
@@ -195,7 +195,7 @@ class ETLApp(tk.Tk):
         self._dir_row(card, 4, o_title, self._output, required=True, tip=output_tip)
 
         # ── run button ──────────────────────────
-        btn_frame = tk.Frame(self, bg=BG, pady=22)
+        btn_frame = tk.Frame(self, bg=ax.bg, pady=22)
         btn_frame.pack()
 
         self._run_btn = tk.Button(
@@ -206,10 +206,10 @@ class ETLApp(tk.Tk):
                 if platform_system() == "Windows"
                 else ("Menlo", 11, "bold")
             ),
-            bg=ACCENT,
-            fg="#0d0d10",
-            activebackground=BTN_ACTIVE,
-            activeforeground="#0d0d10",
+            bg=ax.accent,
+            fg=ax.fg_black,
+            activebackground=ax.btn_active,
+            activeforeground=ax.fg_black,
             relief="flat",
             bd=0,
             padx=28,
@@ -223,35 +223,38 @@ class ETLApp(tk.Tk):
         table.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
 
         # hover effect
-        self._run_btn.bind("<Enter>", lambda _: self._run_btn.configure(bg=BTN_ACTIVE))
-        self._run_btn.bind("<Leave>", lambda _: self._run_btn.configure(bg=ACCENT))
+        self._run_btn.bind(
+            "<Enter>", lambda _: self._run_btn.configure(bg=ax.btn_active)
+        )
+        self._run_btn.bind("<Leave>", lambda _: self._run_btn.configure(bg=ax.accent))
 
         # ── status bar ──────────────────────────
         self._status = tk.StringVar(value="Ready.")
         status_bar = tk.Label(
             self,
             textvariable=self._status,
-            font=MONO,
-            bg=BG,
-            fg=FG_DIM,
+            font=ax.mono,
+            bg=ax.bg,
+            fg=ax.fg_dim,
             anchor="w",
             padx=28,
             pady=6,
         )
         status_bar.pack(fill="x", side="bottom")
 
-        tk.Frame(self, bg=BORDER, height=1).pack(fill="x", side="bottom")
+        tk.Frame(self, bg=ax.border, height=1).pack(fill="x", side="bottom")
 
     def _dir_row(self, parent, row, label, var, *, required, tip):
         """Render one label + entry + browse button row."""
+        ax = get_app_glb_attrs()
         lbl_text = f"{'*' if required else ' '} {label}"
 
         tk.Label(
             parent,
             text=lbl_text,
-            font=MONO,
-            bg=BG_CARD,
-            fg=ACCENT if required else FG_DIM,
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.accent if required else ax.fg_dim,
             width=14,
             anchor="w",
         ).grid(row=row, column=0, padx=(0, 10), pady=7, sticky="w")
@@ -259,16 +262,16 @@ class ETLApp(tk.Tk):
         entry = tk.Entry(
             parent,
             textvariable=var,
-            font=MONO,
-            bg=ENTRY_BG,
-            fg=FG,
-            insertbackground=ACCENT,
+            font=ax.mono,
+            bg=ax.entry_bg,
+            fg=ax.fg,
+            insertbackground=ax.accent,
             relief="flat",
             bd=0,
             width=32,
             highlightthickness=1,
-            highlightbackground=BORDER,
-            highlightcolor=ACCENT,
+            highlightbackground=ax.border,
+            highlightcolor=ax.accent,
         )
         entry.grid(row=row, column=1, pady=7, ipady=5, sticky="ew")
 
@@ -279,10 +282,10 @@ class ETLApp(tk.Tk):
         tk.Button(
             parent,
             text="…",
-            font=MONO,
-            bg=BORDER,
-            fg=FG,
-            activebackground=ACCENT,
+            font=ax.mono,
+            bg=ax.border,
+            fg=ax.fg,
+            activebackground=ax.accent,
             activeforeground="#0d0d10",
             relief="flat",
             bd=0,
@@ -291,19 +294,35 @@ class ETLApp(tk.Tk):
             cursor="hand2",
             command=lambda v=var: self._browse(v),
         ).grid(row=row, column=2, padx=(8, 0), pady=7)
-
+        tk.Button(
+            parent,
+            text="📂",  # or use "📂" if your font supports it
+            font=ax.mono,
+            bg=ax.border,
+            fg=ax.fg,
+            activebackground=ax.accent,
+            activeforeground="#0d0d10",
+            relief="flat",
+            bd=0,
+            padx=10,
+            pady=4,
+            cursor="hand2",
+            command=lambda v=var: self._open_dir(v),
+        ).grid(row=row, column=3, padx=(4, 0), pady=7)
         parent.columnconfigure(1, weight=1)
+        parent.columnconfigure(3, weight=0)
 
     def _text_row(self, parent, row, label, var, *, required, tip):
         """Render one label + plain text entry row (no browse button)."""
+        ax = get_app_glb_attrs()
         lbl_text = f"{'*' if required else ' '} {label}"
 
         tk.Label(
             parent,
             text=lbl_text,
-            font=MONO,
-            bg=BG_CARD,
-            fg=ACCENT if required else FG_DIM,
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.accent if required else ax.fg_dim,
             width=14,
             anchor="w",
         ).grid(row=row, column=0, padx=(0, 10), pady=7, sticky="w")
@@ -311,16 +330,16 @@ class ETLApp(tk.Tk):
         entry = tk.Entry(
             parent,
             textvariable=var,
-            font=MONO,
-            bg=ENTRY_BG,
-            fg=FG,
-            insertbackground=ACCENT,
+            font=ax.mono,
+            bg=ax.entry_bg,
+            fg=ax.fg,
+            insertbackground=ax.accent,
             relief="flat",
             bd=0,
             width=32,
             highlightthickness=1,
-            highlightbackground=BORDER,
-            highlightcolor=ACCENT,
+            highlightbackground=ax.border,
+            highlightcolor=ax.accent,
         )
         entry.grid(row=row, column=1, columnspan=2, pady=7, ipady=5, sticky="ew")
 
@@ -330,18 +349,19 @@ class ETLApp(tk.Tk):
     @staticmethod
     def _placeholder(entry, var, tip):
         """Light placeholder text for optional fields."""
-        entry.configure(fg=FG_DIM)
+        ax = get_app_glb_attrs()
+        entry.configure(fg=ax.fg_dim)
         entry.insert(0, tip)
 
         def on_focus_in(_):
             if var.get() == tip:
                 entry.delete(0, "end")
-                entry.configure(fg=FG)
+                entry.configure(fg=ax.fg)
 
         def on_focus_out(_):
             if not entry.get():
                 entry.insert(0, tip)
-                entry.configure(fg=FG_DIM)
+                entry.configure(fg=ax.fg_dim)
                 var.set("")  # keep the StringVar clean
 
         entry.bind("<FocusIn>", on_focus_in)
@@ -355,6 +375,7 @@ class ETLApp(tk.Tk):
 
     # ── run handler ────────────────────────────
     def _run(self):
+        ax = get_app_glb_attrs()
         person = self._person.get().strip()
         working = self._working.get().strip()
         b_src_dir_ = self._b_src_dir.get().strip()
@@ -376,7 +397,7 @@ class ETLApp(tk.Tk):
             return
 
         # Lock UI
-        self._run_btn.configure(state="disabled", text="⏳  Running…", bg=ACCENT_DIM)
+        self._run_btn.configure(state="disabled", text="⏳  Running…", bg=ax.accent_DIM)
         self._status.set("Running ETL pipeline…")
         self.update_idletasks()
 
@@ -388,7 +409,9 @@ class ETLApp(tk.Tk):
             self._status.set(f"✘  Error: {exc}")
             tkinter_messagebox.showerror("Pipeline error", str(exc))
         finally:
-            self._run_btn.configure(state="normal", text="▶  RUN PIPELINE", bg=ACCENT)
+            self._run_btn.configure(
+                state="normal", text="▶  RUN PIPELINE", bg=ax.accent
+            )
 
         # Open output directory if one was given
         if output and os_path_isdir(output):

--- a/src/ch30_etl_app/etl_gui_tool.py
+++ b/src/ch30_etl_app/etl_gui_tool.py
@@ -36,11 +36,14 @@ class ETLAppSettings:
     fg_black: str
     entry_bg: str
     btn_active: str
+    platform_font: str
 
 
 def get_app_glb_attrs() -> ETLAppSettings:
+    is_windows = platform_system() == "Windows"
+    platform_font = ("Courier New", 17, "bold") if is_windows else ("Menlo", 16, "bold")
     return ETLAppSettings(
-        mono=("Courier New", 9) if platform_system() == "Windows" else ("Menlo", 10),
+        mono=("Courier New", 9) if is_windows else ("Menlo", 10),
         bg="#1a1a1f",
         bg_card="#22222a",
         border="#33333d",
@@ -51,6 +54,7 @@ def get_app_glb_attrs() -> ETLAppSettings:
         fg_black="#0d0d10",
         entry_bg="#13131a",
         btn_active="#f0d060",
+        platform_font=platform_font,
     )
 
 
@@ -189,30 +193,40 @@ def get_option_table_options() -> dict[str, Callable]:
         "create_example_moment_budget_file": create_example_moment_budget_file,
     }
 
-
-def add_open_dir_button(
-    app_self,
-    parent,
-    var,
-    row,
-    mono_font,
-    bg_border,
-    fg,
-    accent,
-    open_dir_func: Callable,
-):
-    app_self.Button(
-        parent,
-        text="📂",
-        font=mono_font,
-        bg=bg_border,
-        fg=fg,
-        activebackground=accent,
-        activeforeground="#0d0d10",
-        relief="flat",
-        bd=0,
-        padx=10,
-        pady=4,
-        cursor="hand2",
-        command=lambda v=var: open_dir_func(v),
-    ).grid(row=row, column=3, padx=(4, 0), pady=7)
+    # main_rows_config = {
+    #     "0": {
+    #         "row_type": "text",
+    #         "title": "PERSON NAME",
+    #         "var": self._person,
+    #         "required": True,
+    #         "tip": "e.g. 'Emmanuel'",
+    #     },
+    #     "1": {
+    #         "row_type": "dir",
+    #         "title": "WORKING DIR",
+    #         "var": self._working,
+    #         "required": True,
+    #         "tip": "Root directory for the ETL process",
+    #     },
+    #     "2": {
+    #         "row_type": "dir",
+    #         "title": "BELIEFS_DIR",
+    #         "var": self._b_src_dir,
+    #         "required": True,
+    #         "tip": "Source of Beliefs. Non-sparked Ideas.",
+    #     },
+    #     "3": {
+    #         "row_type": "dir",
+    #         "title": "IDEAS_DIR  ",
+    #         "var": self._i_src_dir,
+    #         "required": True,
+    #         "tip": "Source of Ideas files. Beliefs that have been sparked.",
+    #     },
+    #     "4": {
+    #         "row_type": "dir",
+    #         "title": "OUTPUT DIR ",
+    #         "var": self._output,
+    #         "required": True,
+    #         "tip": "Destination for results (opened on finish)",
+    #     },
+    # }

--- a/src/ch30_etl_app/etl_gui_tool.py
+++ b/src/ch30_etl_app/etl_gui_tool.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from pathlib import Path
+from platform import system as platform_system
 from src.ch00_py.csv_toolbox import (
     delete_column_from_csv_string,
     replace_csv_column_from_string,
@@ -21,8 +23,39 @@ from src.ch21_world.world import worlddir_shop
 from typing import Callable
 
 
+@dataclass
+class ETLAppSettings:
+    mono: str
+    bg: str
+    bg_card: str
+    border: str
+    accent: str
+    accent_dim: str
+    fg: str
+    fg_dim: str
+    fg_black: str
+    entry_bg: str
+    btn_active: str
+
+
+def get_app_glb_attrs() -> ETLAppSettings:
+    return ETLAppSettings(
+        mono=("Courier New", 9) if platform_system() == "Windows" else ("Menlo", 10),
+        bg="#1a1a1f",
+        bg_card="#22222a",
+        border="#33333d",
+        accent="#e8c547",
+        accent_dim="#b89a2f",
+        fg="#e4e4e8",
+        fg_dim="#7a7a88",
+        fg_black="#0d0d10",
+        entry_bg="#13131a",
+        btn_active="#f0d060",
+    )
+
+
 def get_app_default_person_name() -> str:
-    return "Steve"
+    return "Emmanuel"
 
 
 def get_app_default_world_name() -> str:
@@ -155,3 +188,31 @@ def get_option_table_options() -> dict[str, Callable]:
         "create_example_moment_ledger_file": create_example_moment_ledger_file,
         "create_example_moment_budget_file": create_example_moment_budget_file,
     }
+
+
+def add_open_dir_button(
+    app_self,
+    parent,
+    var,
+    row,
+    mono_font,
+    bg_border,
+    fg,
+    accent,
+    open_dir_func: Callable,
+):
+    app_self.Button(
+        parent,
+        text="📂",
+        font=mono_font,
+        bg=bg_border,
+        fg=fg,
+        activebackground=accent,
+        activeforeground="#0d0d10",
+        relief="flat",
+        bd=0,
+        padx=10,
+        pady=4,
+        cursor="hand2",
+        command=lambda v=var: open_dir_func(v),
+    ).grid(row=row, column=3, padx=(4, 0), pady=7)

--- a/src/ch30_etl_app/test/test_default_app_dir.py
+++ b/src/ch30_etl_app/test/test_default_app_dir.py
@@ -27,6 +27,7 @@ def test_ETLAppSettings_Exists():
     x_fg_black = "xx_fg_black"
     x_entry_bg = "xx_entry_bg"
     x_btn_active = "xx_btn_active"
+    x_platform_font = "xx_platform_font"
     # WHEN
     app_settings = ETLAppSettings(
         mono=x_mono,
@@ -40,6 +41,7 @@ def test_ETLAppSettings_Exists():
         fg_black=x_fg_black,
         entry_bg=x_entry_bg,
         btn_active=x_btn_active,
+        platform_font=x_platform_font,
     )
     # THEN
     assert app_settings
@@ -73,7 +75,13 @@ def test_get_app_glb_attrs_ReturnsObj():
         "entry_bg",
         "btn_active",
         "fg_black",
+        "platform_font",
     }
+    expected_platform_font = (
+        ("Courier New", 17, "bold")
+        if platform_system() == "Windows"
+        else ("Menlo", 16, "bold")
+    )
     expected_app_settings = ETLAppSettings(
         mono=("Courier New", 9) if platform_system() == "Windows" else ("Menlo", 10),
         bg="#1a1a1f",
@@ -86,6 +94,7 @@ def test_get_app_glb_attrs_ReturnsObj():
         fg_black="#0d0d10",
         entry_bg="#13131a",
         btn_active="#f0d060",
+        platform_font=expected_platform_font,
     )
     assert app_glb_attrs == expected_app_settings
 

--- a/src/ch30_etl_app/test/test_default_app_dir.py
+++ b/src/ch30_etl_app/test/test_default_app_dir.py
@@ -1,19 +1,98 @@
 from os import name as os_name
 from pathlib import Path
+from platform import system as platform_system
 from pytest import MonkeyPatch
 from src.ch21_world.world import worlddir_shop
 from src.ch30_etl_app.etl_gui_tool import (
+    ETLAppSettings,
     get_app_default_dir,
     get_app_default_person_name,
     get_app_default_world_name,
+    get_app_glb_attrs,
     get_workspace_dirs,
 )
 import sys
 
 
+def test_ETLAppSettings_Exists():
+    # ESTABLISH
+    x_mono = "xx_mono"
+    x_bg = "xx_bg"
+    x_bg_card = "xx_bg_card"
+    x_border = "xx_border"
+    x_accent = "xx_accent"
+    x_accent_dim = "xx_accent_dim"
+    x_fg = "xx_fg"
+    x_fg_dim = "xx_fg_dim"
+    x_fg_black = "xx_fg_black"
+    x_entry_bg = "xx_entry_bg"
+    x_btn_active = "xx_btn_active"
+    # WHEN
+    app_settings = ETLAppSettings(
+        mono=x_mono,
+        bg=x_bg,
+        bg_card=x_bg_card,
+        border=x_border,
+        accent=x_accent,
+        accent_dim=x_accent_dim,
+        fg=x_fg,
+        fg_dim=x_fg_dim,
+        fg_black=x_fg_black,
+        entry_bg=x_entry_bg,
+        btn_active=x_btn_active,
+    )
+    # THEN
+    assert app_settings
+    assert app_settings.mono
+    assert app_settings.bg
+    assert app_settings.bg_card
+    assert app_settings.border
+    assert app_settings.accent
+    assert app_settings.accent_dim
+    assert app_settings.fg
+    assert app_settings.fg_dim
+    assert app_settings.entry_bg
+    assert app_settings.btn_active
+
+
+def test_get_app_glb_attrs_ReturnsObj():
+    # ESTABLISH / WHEN
+    app_glb_attrs = get_app_glb_attrs()
+
+    # THEN
+    assert app_glb_attrs
+    assert set(app_glb_attrs.__dict__.keys()) == {
+        "mono",
+        "bg",
+        "bg_card",
+        "border",
+        "accent",
+        "accent_dim",
+        "fg",
+        "fg_dim",
+        "entry_bg",
+        "btn_active",
+        "fg_black",
+    }
+    expected_app_settings = ETLAppSettings(
+        mono=("Courier New", 9) if platform_system() == "Windows" else ("Menlo", 10),
+        bg="#1a1a1f",
+        bg_card="#22222a",
+        border="#33333d",
+        accent="#e8c547",
+        accent_dim="#b89a2f",
+        fg="#e4e4e8",
+        fg_dim="#7a7a88",
+        fg_black="#0d0d10",
+        entry_bg="#13131a",
+        btn_active="#f0d060",
+    )
+    assert app_glb_attrs == expected_app_settings
+
+
 def test_get_app_default_person_name_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    assert get_app_default_person_name() == "Steve"
+    assert get_app_default_person_name() == "Emmanuel"
 
 
 def test_get_app_default_world_name_ReturnsObj():


### PR DESCRIPTION
## Summary by Sourcery

Centralize ETL GUI appearance settings and refresh the launcher UI layout and behavior.

New Features:
- Introduce an ETLAppSettings dataclass and get_app_glb_attrs helper to provide centralized, platform-aware GUI styling attributes.
- Add an open-folder button to each directory row in the ETL launcher to open the selected path in the system file explorer.

Enhancements:
- Refactor the ETL launcher window to consume shared styling settings, adjust default window size, and slightly refresh the visual layout and fonts.

Tests:
- Add tests for ETLAppSettings and get_app_glb_attrs to verify expected styling attributes and platform font selection.
- Update the default person-name test to reflect the new default value.