### PR TITLE
fix: #1124 changed publish.yaml to automatically set version number w…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write  # required for trusted publishing
+      id-token: write
 
     steps:
       - name: Checkout
@@ -19,14 +19,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set version from tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+          sed -i "s/^version = .*/version = \"$TAG\"/" pyproject.toml
+
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           pip install build
 
       - name: Build package
-        run: |
-          python -m build
+        run: python -m build
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
…hen releasing to pypi

## Summary by Sourcery

Build:
- Configure the publish workflow to set the pyproject.toml version from the Git tag referenced by GITHUB_REF prior to building the package.