### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch30_etl_app/test/test_z_app_runs.py
+++ b/src/ch30_etl_app/test/test_z_app_runs.py
@@ -1,0 +1,14 @@
+from ch30_etl_app.etl_gui_main import ETLApp
+
+
+def test_ETLApp_ApplicationInitRunsWithoutError():
+    # ESTABLISH / WHEN
+    root = ETLApp()
+    # Schedule close almost immediately
+    root.after(100, root.destroy)
+
+    # THEN
+    try:
+        root.mainloop()
+    except Exception as e:
+        assert False, f"Tkinter app crashed: {e}"

--- a/src/ch30_etl_app/test/test_z_app_runs.py
+++ b/src/ch30_etl_app/test/test_z_app_runs.py
@@ -1,6 +1,12 @@
 from ch30_etl_app.etl_gui_main import ETLApp
+from os import environ as os_environ
+from pytest import mark as pytest_mark
 
 
+@pytest_mark.skipif(
+    not os_environ.get("DISPLAY"),
+    reason="No display available for Tkinter",
+)
 def test_ETLApp_ApplicationInitRunsWithoutError():
     # ESTABLISH / WHEN
     root = ETLApp()


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Add a Tkinter ETL application initialization test that runs the main loop briefly and verifies it does not crash, skipping when no DISPLAY is available.