### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/src/ch22_heard/test/heard/test_heard_raw_tables_translate_updates.py
+++ b/src/ch22_heard/test/heard/test_heard_raw_tables_translate_updates.py
@@ -29,26 +29,26 @@ def test_create_update_heard_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario0_
     prnawar_h_raw_put_tablename = prime_tbl(prnawar_dimen, kw.h_raw, "put")
     # print(f"{get_table_columns(cursor0, prnawar_h_raw_put_tablename)=}")
     insert_spark_face_only_sqlstr = f"""INSERT INTO {prnawar_h_raw_put_tablename} 
-    ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
-    VALUES
-      ({spark1}, '{sue_otx}', NULL)
-    , ({spark2}, '{yao_otx}', NULL)
-    , ({spark5}, '{sue_otx}', NULL)
-    , ({spark7}, '{bob_otx}', NULL)
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
+VALUES
+    ({spark1}, '{sue_otx}', NULL)
+, ({spark2}, '{yao_otx}', NULL)
+, ({spark5}, '{sue_otx}', NULL)
+, ({spark7}, '{bob_otx}', NULL)
+;
+"""
     cursor0.execute(insert_spark_face_only_sqlstr)
 
     trlname_dimen = kw.translate_name
     trlname_s_vld_tablename = prime_tbl(trlname_dimen, kw.s_vld)
     print(f"{trlname_s_vld_tablename=}")
     insert_trlname_sqlstr = f"""INSERT INTO {trlname_s_vld_tablename} 
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
-    VALUES
-      ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
+VALUES
+    ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+, ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+;
+"""
     cursor0.execute(insert_trlname_sqlstr)
 
     spark_face_inx_count_sql = f"SELECT COUNT(*) FROM {prnawar_h_raw_put_tablename} WHERE {kw.spark_face}_inx IS NOT NULL"
@@ -93,24 +93,24 @@ def test_create_update_heard_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario1_
     prnawar_dimen = kw.person_plan_awardunit
     prnawar_h_raw_put_tablename = prime_tbl(prnawar_dimen, kw.h_raw, "put")
     insert_spark_face_only_sqlstr = f"""INSERT INTO {prnawar_h_raw_put_tablename}
-    ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
-    VALUES
-      ({spark1}, '{sue_otx}', NULL)
-    , ({spark2}, '{yao_otx}', NULL)
-    , ({spark5}, '{bob_otx}', NULL)
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
+VALUES
+  ({spark1}, '{sue_otx}', NULL)
+, ({spark2}, '{yao_otx}', NULL)
+, ({spark5}, '{bob_otx}', NULL)
+;
+"""
     cursor0.execute(insert_spark_face_only_sqlstr)
     trlname_dimen = kw.translate_name
     trlname_s_vld_tablename = prime_tbl(trlname_dimen, kw.s_vld)
     print(f"{trlname_s_vld_tablename=}")
     insert_trlname_sqlstr = f"""INSERT INTO {trlname_s_vld_tablename}
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
-    VALUES
-      ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
+VALUES
+  ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+, ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+;
+"""
     cursor0.execute(insert_trlname_sqlstr)
 
     spark_face_inx_count_sql = f"SELECT COUNT(*) FROM {prnawar_h_raw_put_tablename} WHERE {kw.spark_face}_inx IS NOT NULL"
@@ -161,31 +161,31 @@ def test_create_update_heard_raw_existing_inx_col_sqlstr_UpdatesTable_Scenario2_
     prnawar_h_raw_put_tablename = prime_tbl(prnawar_dimen, kw.h_raw, "put")
     print(f"{get_table_columns(cursor0, prnawar_h_raw_put_tablename)=}")
     insert_spark_face_only_sqlstr = f"""INSERT INTO {prnawar_h_raw_put_tablename}
-    ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
-    VALUES
-      ({spark0}, '{bob_otx}', NULL)
-    , ({spark1}, '{bob_otx}', NULL)
-    , ({spark2}, '{yao_otx}', NULL)
-    , ({spark5}, '{bob_otx}', NULL)
-    , ({spark7}, '{bob_otx}', NULL)
-    , ({spark9}, '{bob_otx}', NULL)
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
+VALUES
+  ({spark0}, '{bob_otx}', NULL)
+, ({spark1}, '{bob_otx}', NULL)
+, ({spark2}, '{yao_otx}', NULL)
+, ({spark5}, '{bob_otx}', NULL)
+, ({spark7}, '{bob_otx}', NULL)
+, ({spark9}, '{bob_otx}', NULL)
+;
+"""
     cursor0.execute(insert_spark_face_only_sqlstr)
 
     trlname_dimen = kw.translate_name
     trlname_s_vld_tablename = prime_tbl(trlname_dimen, kw.s_vld)
     print(f"{trlname_s_vld_tablename=}")
     insert_trlname_sqlstr = f"""INSERT INTO {trlname_s_vld_tablename}
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
-    VALUES
-      ({spark1}, '{bob_otx}', '{bob_otx}', '{bob_inx0}')
-    , ({spark2}, '{yao_otx}', '{yao_otx}', '{yao_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx7}')
-    , ({spark7}, '{bob_otx}', '{sue_otx}', '{bob_sue_inx}')
-    , ({spark8}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
+VALUES
+  ({spark1}, '{bob_otx}', '{bob_otx}', '{bob_inx0}')
+, ({spark2}, '{yao_otx}', '{yao_otx}', '{yao_inx}')
+, ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx7}')
+, ({spark7}, '{bob_otx}', '{sue_otx}', '{bob_sue_inx}')
+, ({spark8}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+;
+"""
     cursor0.execute(insert_trlname_sqlstr)
 
     spark_face_inx_count_sql = f"SELECT COUNT(*) FROM {prnawar_h_raw_put_tablename} WHERE {kw.spark_face}_inx IS NOT NULL"
@@ -236,7 +236,8 @@ def test_create_update_heard_raw_empty_inx_col_sqlstr_UpdatesTable_Scenario0_Emp
     prnawar_dimen = kw.person_plan_awardunit
     prnawar_h_raw_put_tablename = prime_tbl(prnawar_dimen, kw.h_raw, "put")
     print(f"{get_table_columns(cursor0, prnawar_h_raw_put_tablename)=}")
-    insert_spark_face_only_sqlstr = f"""INSERT INTO {prnawar_h_raw_put_tablename} ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
+    insert_spark_face_only_sqlstr = f"""
+INSERT INTO {prnawar_h_raw_put_tablename} ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
 VALUES
   ({spark1}, '{sue_otx}', '{sue_inx}')
 , ({spark2}, '{yao_otx}', NULL)
@@ -291,32 +292,33 @@ def test_set_all_heard_raw_inx_columns_Scenario0_empty_tables(cursor0: Cursor):
     prnawar_dimen = kw.person_plan_awardunit
     prnawar_h_raw_put_tablename = prime_tbl(prnawar_dimen, kw.h_raw, "put")
     print(f"{get_table_columns(cursor0, prnawar_h_raw_put_tablename)=}")
-    insert_spark_face_only_sqlstr = f"""INSERT INTO {prnawar_h_raw_put_tablename}
-    ({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
-    VALUES
-      ({spark0}, '{bob_otx}', NULL)
-    , ({spark1}, '{bob_otx}', NULL)
-    , ({spark2}, '{yao_otx}', NULL)
-    , ({spark5}, '{bob_otx}', NULL)
-    , ({spark7}, '{bob_otx}', NULL)
-    , ({spark9}, '{bob_otx}', NULL)
-    ;
-    """
+    insert_spark_face_only_sqlstr = f"""
+INSERT INTO {prnawar_h_raw_put_tablename}
+({kw.spark_num}, {kw.spark_face}_otx, {kw.spark_face}_inx)
+VALUES
+    ({spark0}, '{bob_otx}', NULL)
+, ({spark1}, '{bob_otx}', NULL)
+, ({spark2}, '{yao_otx}', NULL)
+, ({spark5}, '{bob_otx}', NULL)
+, ({spark7}, '{bob_otx}', NULL)
+, ({spark9}, '{bob_otx}', NULL)
+;
+"""
     cursor0.execute(insert_spark_face_only_sqlstr)
 
     trlname_dimen = kw.translate_name
     trlname_s_vld_tablename = prime_tbl(trlname_dimen, kw.s_vld)
     print(f"{trlname_s_vld_tablename=}")
     insert_trlname_sqlstr = f"""INSERT INTO {trlname_s_vld_tablename}
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
-    VALUES
-      ({spark1}, '{bob_otx}', '{bob_otx}', '{bob_inx0}')
-    , ({spark2}, '{yao_otx}', '{yao_otx}', '{yao_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx7}')
-    , ({spark7}, '{bob_otx}', '{sue_otx}', '{bob_sue_inx}')
-    , ({spark8}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    ;
-    """
+({kw.spark_num}, {kw.spark_face}, {kw.otx_name}, {kw.inx_name})
+VALUES
+    ({spark1}, '{bob_otx}', '{bob_otx}', '{bob_inx0}')
+, ({spark2}, '{yao_otx}', '{yao_otx}', '{yao_inx}')
+, ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx7}')
+, ({spark7}, '{bob_otx}', '{sue_otx}', '{bob_sue_inx}')
+, ({spark8}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+;
+"""
     cursor0.execute(insert_trlname_sqlstr)
 
     spark_face_inx_count_sql = f"SELECT COUNT(*) FROM {prnawar_h_raw_put_tablename} WHERE {kw.spark_face}_inx IS NOT NULL"

--- a/src/ch24_belief_dst/test/belief/test_belief_translate.py
+++ b/src/ch24_belief_dst/test/belief/test_belief_translate.py
@@ -35,22 +35,22 @@ def test_add_to_ii00142_csv_ReturnsObj(cursor0: Cursor):
     trltitl_dimen = kw.translate_title
     trltitl_s_vld_tablename = prime_tbl(trltitl_dimen, kw.s_vld)
     insert_trltitl_sqlstr = f"""INSERT INTO {trltitl_s_vld_tablename}
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_title}, {kw.inx_title})
-    VALUES
-      ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-    ;
-    """
+  ({kw.spark_num}, {kw.spark_face}, {kw.otx_title}, {kw.inx_title})
+  VALUES
+    ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+  , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+  ;
+  """
     cursor0.execute(insert_trltitl_sqlstr)
 
     trlcore_s_vld_tablename = prime_tbl("TRLCORE", kw.s_vld)
     insert_trlcore_sqlstr = f"""INSERT INTO {trlcore_s_vld_tablename}
-    ({kw.spark_face}, {kw.otx_knot}, {kw.inx_knot}, {kw.unknown_str})
-    VALUES
-      ('{sue_otx}', '{sue_otx_knot}', '{sue_inx_knot}', '{sue_unknown_str}')
-    , ('{bob_otx}', '{bob_otx_knot}', '{bob_inx_knot}', '{bob_unknown_str}')
-    ;
-    """
+  ({kw.spark_face}, {kw.otx_knot}, {kw.inx_knot}, {kw.unknown_str})
+  VALUES
+    ('{sue_otx}', '{sue_otx_knot}', '{sue_inx_knot}', '{sue_unknown_str}')
+  , ('{bob_otx}', '{bob_otx_knot}', '{bob_inx_knot}', '{bob_unknown_str}')
+  ;
+  """
     cursor0.execute(insert_trlcore_sqlstr)
 
     csv_delimiter = ","
@@ -275,12 +275,12 @@ def test_add_translate_rows_to_belief_csv_strs_ReturnsObj(cursor0: Cursor):
     trltitl_dimen = kw.translate_title
     trltitl_s_vld_tablename = prime_tbl(trltitl_dimen, kw.s_vld)
     insert_trltitl_sqlstr = f"""INSERT INTO {trltitl_s_vld_tablename}
-    ({kw.spark_num}, {kw.spark_face}, {kw.otx_title}, {kw.inx_title})
-    VALUES
-      ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
-    , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
-    ;
-    """
+  ({kw.spark_num}, {kw.spark_face}, {kw.otx_title}, {kw.inx_title})
+  VALUES
+    ({spark1}, '{sue_otx}', '{sue_otx}', '{sue_inx}')
+  , ({spark7}, '{bob_otx}', '{bob_otx}', '{bob_inx}')
+  ;
+  """
     cursor0.execute(insert_trltitl_sqlstr)
 
     # insert translate_name records
@@ -333,12 +333,12 @@ VALUES
     # insert translate_core records
     trlcore_s_vld_tablename = prime_tbl("TRLCORE", kw.s_vld)
     insert_trlcore_sqlstr = f"""INSERT INTO {trlcore_s_vld_tablename}
-    ({kw.spark_face}, {kw.otx_knot}, {kw.inx_knot}, {kw.unknown_str})
-    VALUES
-      ('{sue_otx}', '{sue_otx_knot}', '{sue_inx_knot}', '{sue_unknown_str}')
-    , ('{bob_otx}', '{bob_otx_knot}', '{bob_inx_knot}', '{bob_unknown_str}')
-    ;
-    """
+  ({kw.spark_face}, {kw.otx_knot}, {kw.inx_knot}, {kw.unknown_str})
+  VALUES
+    ('{sue_otx}', '{sue_otx_knot}', '{sue_inx_knot}', '{sue_unknown_str}')
+  , ('{bob_otx}', '{bob_otx_knot}', '{bob_inx_knot}', '{bob_unknown_str}')
+  ;
+  """
     cursor0.execute(insert_trlcore_sqlstr)
 
     csv_delimiter = ","

--- a/src/ch25_kpi/gcalendar.py
+++ b/src/ch25_kpi/gcalendar.py
@@ -181,14 +181,12 @@ def get_gcal_priorities_schedule_str(dayevents: list[DayEvent]) -> str:
     inflections_dict = get_inflection_points_dict(dayevents)
     x_str = "Schedule Priorities"
     for inflection_minute in sorted(list(inflections_dict.keys())):
-        dayevent = inflections_dict.get(inflection_minute)
-        if dayevent:
+        if dayevent := inflections_dict.get(inflection_minute):
             precent_str = gcal_readable_percent(dayevent.plan.fund_ratio)
             x_str += f"\n{dayevent.clock_lower} {dayevent.item_rank}. {dayevent.plan.plan_label} {precent_str}"
             previous_dayevent = dayevent
-        else:
-            if previous_dayevent:
-                x_str += f"\n{previous_dayevent.clock_upper} Nothing scheduled."
+        elif previous_dayevent:
+            x_str += f"\n{previous_dayevent.clock_upper} Nothing scheduled."
     return x_str
 
 
@@ -432,7 +430,8 @@ def lynx_to_person_gcal_day_punchs(
 
 def copy_person_day_punches_to_dst_dir(
     moment_mstr_dir: str, dst_dir: str, person_name: PersonName
-):
+) -> set[str]:
+    dst_person_punch_paths = {}
     moments_dir = create_moments_dir_path(moment_mstr_dir)
     for moment_label in get_level1_dirs(moments_dir):
         moment_lasso = lassounit_shop(create_rope(moment_label))
@@ -446,3 +445,8 @@ def copy_person_day_punches_to_dst_dir(
                 )
                 day_punch_file_path = create_path(day_punchs_path, person_filename)
                 save_file(dst_person_punch_path, None, open_file(day_punch_file_path))
+                if dst_person_punch_paths.get(moment_lasso.moment_rope) is None:
+                    dst_person_punch_paths[moment_lasso.moment_rope] = set()
+                paths_set = dst_person_punch_paths.get(moment_lasso.moment_rope)
+                paths_set.add(dst_person_punch_path)
+    return dst_person_punch_paths

--- a/src/ch25_kpi/test/test_person_calendar/test_gcal_day_report.py
+++ b/src/ch25_kpi/test/test_person_calendar/test_gcal_day_report.py
@@ -295,7 +295,7 @@ def test_copy_person_day_punches_to_dst_dir_SavesFiles_Scenario0_TwoSueReports(
     assert not os_path_exists(sue_ep8_dst_punch_path)
 
     # WHEN
-    copy_person_day_punches_to_dst_dir(
+    dst_person_punch_paths = copy_person_day_punches_to_dst_dir(
         moment_mstr_dir=mmt_mstr_dir,
         dst_dir=dst_dir,
         person_name=exx.sue,
@@ -304,3 +304,11 @@ def test_copy_person_day_punches_to_dst_dir_SavesFiles_Scenario0_TwoSueReports(
     # THEN
     assert os_path_exists(sue_a23_dst_punch_path)
     assert os_path_exists(sue_ep8_dst_punch_path)
+    for dst_person_punch_path in dst_person_punch_paths:
+        print(f"{dst_person_punch_path=}")
+    print(f"{sue_a23_dst_punch_path=}")
+    print(f"{sue_ep8_dst_punch_path=}")
+    assert dst_person_punch_paths == {
+        exx.a23: {sue_a23_dst_punch_path},
+        exx.ep8: {sue_ep8_dst_punch_path},
+    }

--- a/src/ch26_world/test/test_output/test_gcal_day_output.py
+++ b/src/ch26_world/test/test_output/test_gcal_day_output.py
@@ -1,14 +1,14 @@
 from ch00_py.file_toolbox import create_path, open_file
-from ch04_rope.rope import create_rope, create_rope_from_labels as init_rope
+from ch04_rope.rope import create_rope_from_labels as init_rope
 from ch09_person_lesson._ref.ch09_path import create_moment_json_path
 from ch09_person_lesson.lasso import lassounit_shop
 from ch10_person_listen._ref.ch10_path import create_job_path
-from ch10_person_listen.keep_tool import open_job_file, save_job_file
-from ch13_time.epoch_main import add_epoch_planunit, get_default_epoch_config_dict
-from ch14_moment.moment_main import momentunit_shop, save_moment_file
+from ch10_person_listen.keep_tool import open_job_file
 from ch17_idea.idea_db_tool import save_sheet
-from ch25_kpi._ref.ch25_path import create_day_punch_txt_path as day_punch_path
-from ch26_world.test._util.ch26_examples import ii00002_example
+from ch25_kpi._ref.ch25_path import (
+    create_day_punch_txt_path as day_punch_path,
+    create_dst_person_punch_path,
+)
 from ch26_world.world import (
     belief_sheets_to_gcal_day_punchs,
     create_today_punchs,
@@ -17,7 +17,6 @@ from ch26_world.world import (
 from datetime import datetime
 from os.path import exists as os_path_exists
 from pandas import DataFrame as pandas_DataFrame
-from pytest import fixture as pytest_fixture
 from ref.keywords import Ch26Keywords as kw, ExampleStrs as exx
 
 
@@ -211,7 +210,7 @@ def test_create_today_punchs_SavesFiles_Scenario0_PopulatedSueReport(
     assert not os_path_exists(sue_hn_blu_day_punch_path)
 
     # WHEN
-    create_today_punchs(
+    gen_dst_persons_punch_paths = create_today_punchs(
         person_names={exx.sue},
         world_name=here_wdir.world_name,
         worlds_dir=here_wdir.worlds_dir,
@@ -236,3 +235,17 @@ def test_create_today_punchs_SavesFiles_Scenario0_PopulatedSueReport(
     sue_hn_blu_punch_str = open_file(sue_hn_blu_day_punch_path)
     # print(sue_hn_blu_punch_str)
     assert exx.sweep in sue_hn_blu_punch_str
+    sue_dst_person_punch_path = create_dst_person_punch_path(
+        here_wdir.output_dir, hn_blu_lasso, exx.sue
+    )
+    print(f"{exx.sue=} {sue_dst_person_punch_path=}")
+    expected_dst_persons_punch_paths = {
+        exx.sue: {hn_blu_lasso.moment_rope: {sue_dst_person_punch_path}}
+    }
+    for person_name, gen_dst_file_paths in gen_dst_persons_punch_paths.items():
+        print(f"{person_name=} {gen_dst_file_paths=}")
+    assert gen_dst_persons_punch_paths.keys() == expected_dst_persons_punch_paths.keys()
+    gen_sue_punch_paths = gen_dst_persons_punch_paths.get(exx.sue)
+    expected_sue_punch_paths = expected_dst_persons_punch_paths.get(exx.sue)
+    assert gen_sue_punch_paths == expected_sue_punch_paths
+    assert gen_dst_persons_punch_paths == expected_dst_persons_punch_paths

--- a/src/ch26_world/world.py
+++ b/src/ch26_world/world.py
@@ -214,7 +214,7 @@ def create_today_punchs(
     ideas_src_dir: str = None,
     beliefs_src_dir: str = None,
     focus_group_title: GroupTitle = None,
-):
+) -> dict[PersonName, set]:
     worlddir = worlddir_shop(
         world_name=world_name,
         worlds_dir=worlds_dir,
@@ -228,7 +228,10 @@ def create_today_punchs(
         day=datetime.now(),
         focus_group_title=focus_group_title,
     )
+    dst_persons_punch_paths = {}
     for person_name in person_names:
-        copy_person_day_punches_to_dst_dir(
+        dst_person_punch_paths = copy_person_day_punches_to_dst_dir(
             worlddir.moment_mstr_dir, worlddir.output_dir, person_name
         )
+        dst_persons_punch_paths[person_name] = dst_person_punch_paths
+    return dst_persons_punch_paths

--- a/src/ch30_etl_app/etl_gui_main.py
+++ b/src/ch30_etl_app/etl_gui_main.py
@@ -11,7 +11,7 @@ To integrate your CLI logic, replace the `create_today_punchs()` call inside
 `_run()` with your actual ETL function / subprocess call.
 """
 
-from ch00_py.file_toolbox import delete_dir, set_dir
+from ch00_py.file_toolbox import delete_dir, open_file, set_dir
 from ch17_idea.idea_db_tool import prettify_excel_files
 from ch25_kpi.gcalendar import lynx_to_person_gcal_day_punchs
 from ch26_world.world import create_today_punchs
@@ -515,18 +515,7 @@ class ETLApp(tk_Tk):
         self.update_idletasks()
 
         try:
-            create_today_punchs(
-                person_names={me_person, you_person},
-                world_name=self._world_name.get(),
-                worlds_dir=self._working.get(),
-                output_dir=self._output.get(),
-                ideas_src_dir=self._i_src_dir.get(),
-                beliefs_src_dir=self._b_src_dir.get(),
-            )
-            self._status.set("✔  Pipeline completed successfully.")
-            prettify_excel_files(self._i_src_dir.get())
-            tkinter_messagebox.showinfo("Done", "ETL pipeline finished successfully.")
-
+            self.create_me_you_today_punchs_and_display(me_person, you_person)
         except Exception as exc:  # noqa: BLE001
             self._status.set(f"✘  Error: {exc}")
             tkinter_messagebox.showerror("Pipeline error", str(exc))
@@ -537,6 +526,24 @@ class ETLApp(tk_Tk):
         # Open output directory if one was given
         if output and os_path_isdir(output):
             open_directory(output)
+
+    def create_me_you_today_punchs_and_display(self, me_person: str, you_person: str):
+        persons_punchs = create_today_punchs(
+            person_names={me_person, you_person},
+            world_name=self._world_name.get(),
+            worlds_dir=self._working.get(),
+            output_dir=self._output.get(),
+            ideas_src_dir=self._i_src_dir.get(),
+            beliefs_src_dir=self._b_src_dir.get(),
+        )
+        self._status.set("✔  Pipeline completed successfully.")
+        for person_name, moment_day_punch_paths in persons_punchs.items():
+            for moment_rope, day_punch_paths in moment_day_punch_paths:
+                for day_punch_path in day_punch_paths:
+                    punch_str = open_file(day_punch_path)
+        prettify_excel_files(self._b_src_dir.get())
+        prettify_excel_files(self._i_src_dir.get())
+        tkinter_messagebox.showinfo("Done", "ETL pipeline finished successfully.")
 
 
 # ──────────────────────────────────────────────

--- a/src/ch30_etl_app/etl_gui_main.py
+++ b/src/ch30_etl_app/etl_gui_main.py
@@ -34,11 +34,13 @@ from tkinter import (
     LEFT as tk_LEFT,
     RIGHT as tk_RIGHT,
     VERTICAL as tk_VERTICAL,
+    WORD as tk_WORD,
     Button as tk_Button,
     Entry as tk_Entry,
     Frame as tk_Frame,
     Label as tk_Label,
     StringVar as tk_StringVar,
+    Text as tk_Text,
     Tk as tk_Tk,
     W as tk_W,
     Y as tk_Y,
@@ -46,6 +48,7 @@ from tkinter import (
     messagebox as tkinter_messagebox,
     ttk as tkinter_ttk,
 )
+from tkinter.scrolledtext import ScrolledText as tk_ScrolledText
 
 
 class OptionTable(tk_Frame):
@@ -120,17 +123,22 @@ class ETLAppMissingDefaultError(Exception):
 class ETLApp(tk_Tk):
     def __init__(self):
         super().__init__()
-        self.title(f"Listening using Keg2 (v{metadata_version})")
+        keg_version = metadata_version("keg2")
+        self.title(f"Listening using Keg2 (v{keg_version})")
         self.resizable(False, False)
         ax = get_app_glb_attrs()
         self.configure(bg=ax.bg)
 
         # Set a reasonable minimum size and centre on screen
         self.update_idletasks()
-        app_width, app_height = 640, 640
+        app_width, app_height = 1280, 760
         x = (self.winfo_screenwidth() - app_width) // 2
         y = (self.winfo_screenheight() - app_height) // 2
-        self.geometry(f"{app_width}x{app_height+120}+{x}+{y}")
+        self.geometry(f"{app_width}x{app_height}+{x}+{y}")
+        self.resizable(True, True)
+
+        # Holds data after a run: {person: [(moment, [paths])]}
+        self._persons_punchs_data: dict = {}
 
         # String vars ─ empty string = "not set" (optional dirs stay None)
         self._world_name = tk_StringVar()
@@ -373,8 +381,9 @@ class ETLApp(tk_Tk):
             self._placeholder(entry, var, tip)
 
     def _build_ui(self):
-        # ── header bar ──────────────────────────
         ax = get_app_glb_attrs()
+
+        # ── header bar ──────────────────────────
         header = tk_Frame(self, bg=ax.accent, height=4)
         header.pack(fill="x")
 
@@ -402,13 +411,37 @@ class ETLApp(tk_Tk):
         # ── divider ─────────────────────────────
         tk_Frame(self, bg=ax.border, height=1).pack(fill="x", padx=28)
 
-        # ── directory pickers ───────────────────
-        card = tk_Frame(self, bg=ax.bg_card, bd=0, padx=24, pady=20)
+        # ── status bar (packed to bottom first) ─
+        self._status = tk_StringVar(value="Ready.")
+        tk_Frame(self, bg=ax.border, height=1).pack(fill="x", side="bottom")
+        tk_Label(
+            self,
+            textvariable=self._status,
+            font=ax.mono,
+            bg=ax.bg,
+            fg=ax.fg_dim,
+            anchor="w",
+            padx=28,
+            pady=6,
+        ).pack(fill="x", side="bottom")
+
+        # ── two-column body ──────────────────────
+        body = tk_Frame(self, bg=ax.bg)
+        body.pack(fill=tk_BOTH, expand=True)
+        body.columnconfigure(0, weight=0, minsize=640)
+        body.columnconfigure(1, weight=1)
+        body.rowconfigure(0, weight=1)
+
+        # LEFT PANEL ─────────────────────────────
+        left = tk_Frame(body, bg=ax.bg, width=640)
+        left.grid(row=0, column=0, sticky="nsew")
+        left.pack_propagate(False)
+
+        card = tk_Frame(left, bg=ax.bg_card, bd=0, padx=24, pady=20)
         card.pack(fill="x", padx=28, pady=(16, 0))
         self._create_dir_rows(card)
 
-        # ── run button ──────────────────────────
-        btn_frame = tk_Frame(self, bg=ax.bg, pady=22)
+        btn_frame = tk_Frame(left, bg=ax.bg, pady=22)
         btn_frame.pack()
 
         self._run_btn = tk_Button(
@@ -427,36 +460,209 @@ class ETLApp(tk_Tk):
             command=self._run,
         )
         self._run_btn.pack()
+
         options = get_option_table_options()
         table = OptionTable(
-            self,
+            left,
             options,
             b_src_dir=self._b_src_dir.get,
             me_personname=self._me_personname.get,
         )
         table.pack(fill=tk_BOTH, expand=True, padx=10, pady=10)
 
-        # hover effect
         self._run_btn.bind(
             "<Enter>", lambda _: self._run_btn.configure(bg=ax.btn_active)
         )
         self._run_btn.bind("<Leave>", lambda _: self._run_btn.configure(bg=ax.accent))
 
-        # ── status bar ──────────────────────────
-        self._status = tk_StringVar(value="Ready.")
-        status_bar = tk_Label(
-            self,
-            textvariable=self._status,
-            font=ax.mono,
-            bg=ax.bg,
-            fg=ax.fg_dim,
-            anchor="w",
-            padx=28,
-            pady=6,
-        )
-        status_bar.pack(fill="x", side="bottom")
+        # VERTICAL DIVIDER ───────────────────────
+        tk_Frame(body, bg=ax.border, width=1).grid(row=0, column=0, sticky="nse")
 
-        tk_Frame(self, bg=ax.border, height=1).pack(fill="x", side="bottom")
+        # RIGHT PANEL ────────────────────────────
+        right = tk_Frame(body, bg=ax.bg_card)
+        right.grid(row=0, column=1, sticky="nsew")
+        self._build_viewer_panel(right)
+
+    def _build_viewer_panel(self, parent):
+        """Build the right-side punch file viewer."""
+        ax = get_app_glb_attrs()
+
+        # ── header ──────────────────────────────
+        hdr = tk_Frame(parent, bg=ax.bg_card, pady=12)
+        hdr.pack(fill="x", padx=16)
+
+        tk_Label(
+            hdr,
+            text="PUNCH VIEWER",
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.accent,
+            anchor="w",
+        ).pack(side="left")
+
+        self._copy_btn = tk_Button(
+            hdr,
+            text="⧉  Copy",
+            font=ax.mono,
+            bg=ax.border,
+            fg=ax.fg,
+            activebackground=ax.accent,
+            activeforeground=ax.fg_black,
+            relief="flat",
+            bd=0,
+            padx=10,
+            pady=4,
+            cursor="hand2",
+            command=self._copy_punch_text,
+        )
+        self._copy_btn.pack(side="right")
+
+        tk_Frame(parent, bg=ax.border, height=1).pack(fill="x", padx=16)
+
+        # ── selectors ───────────────────────────
+        sel_frame = tk_Frame(parent, bg=ax.bg_card, pady=10)
+        sel_frame.pack(fill="x", padx=16)
+
+        tk_Label(
+            sel_frame,
+            text="Person",
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.fg_dim,
+            width=8,
+            anchor="w",
+        ).grid(row=0, column=0, padx=(0, 8), pady=4, sticky="w")
+
+        self._person_var = tk_StringVar()
+        self._person_combo = tkinter_ttk.Combobox(
+            sel_frame,
+            textvariable=self._person_var,
+            state="readonly",
+            font=ax.mono,
+            width=20,
+        )
+        self._person_combo.grid(row=0, column=1, pady=4, sticky="ew")
+        self._person_combo.bind("<<ComboboxSelected>>", self._on_person_selected)
+
+        tk_Label(
+            sel_frame,
+            text="Moment",
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.fg_dim,
+            width=8,
+            anchor="w",
+        ).grid(row=1, column=0, padx=(0, 8), pady=4, sticky="w")
+
+        self._moment_var = tk_StringVar()
+        self._moment_combo = tkinter_ttk.Combobox(
+            sel_frame,
+            textvariable=self._moment_var,
+            state="readonly",
+            font=ax.mono,
+            width=20,
+        )
+        self._moment_combo.grid(row=1, column=1, pady=4, sticky="ew")
+        self._moment_combo.bind("<<ComboboxSelected>>", self._on_moment_selected)
+        sel_frame.columnconfigure(1, weight=1)
+
+        tk_Frame(parent, bg=ax.border, height=1).pack(fill="x", padx=16)
+
+        # ── text display ────────────────────────
+        text_frame = tk_Frame(parent, bg=ax.bg_card)
+        text_frame.pack(fill=tk_BOTH, expand=True, padx=16, pady=(8, 16))
+
+        v_scroll = tkinter_ttk.Scrollbar(text_frame, orient=tk_VERTICAL)
+        self._punch_text = tk_Text(
+            text_frame,
+            font=ax.mono,
+            bg=ax.entry_bg,
+            fg=ax.fg,
+            insertbackground=ax.accent,
+            relief="flat",
+            bd=0,
+            wrap=tk_WORD,
+            state="disabled",
+            yscrollcommand=v_scroll.set,
+            highlightthickness=1,
+            highlightbackground=ax.border,
+        )
+        v_scroll.config(command=self._punch_text.yview)
+        v_scroll.pack(side=tk_RIGHT, fill=tk_Y)
+        self._punch_text.pack(side=tk_LEFT, fill=tk_BOTH, expand=True)
+
+        # Hint label when empty
+        self._viewer_hint = tk_Label(
+            parent,
+            text="Run the pipeline to load punch files.",
+            font=ax.mono,
+            bg=ax.bg_card,
+            fg=ax.fg_dim,
+        )
+        self._viewer_hint.place(relx=0.5, rely=0.55, anchor="center")
+
+    # ── viewer helpers ─────────────────────────
+    def _populate_viewer(self, persons_punchs: dict):
+        """Store data and populate the person combobox."""
+        self._persons_punchs_data = persons_punchs
+        names = list(persons_punchs.keys())
+        self._person_combo["values"] = names
+        self._moment_combo["values"] = []
+        self._moment_var.set("")
+        self._person_var.set("")
+        self._set_punch_text("")
+        if names:
+            self._person_combo.current(0)
+            print(f"before {names=}")
+            self._on_person_selected(None)
+            print(f"after3 {names=}")
+            self._viewer_hint.place_forget()
+
+    def _on_person_selected(self, _event):
+        print("huh3")
+        person = self._person_var.get()
+        print("huh4")
+        moments = self._persons_punchs_data.get(person, [])
+        print(f"{moments=}")
+        moment_names = [str(m) for m, _paths in moments.items()]
+        print("huh6")
+        self._moment_combo["values"] = moment_names
+        print("huh7")
+        self._moment_var.set("")
+        self._set_punch_text("")
+        print("huh9")
+        if moment_names:
+            self._moment_combo.current(0)
+            self._on_moment_selected(None)
+
+    def _on_moment_selected(self, _event):
+        person = self._person_var.get()
+        moment_label = self._moment_var.get()
+        moments = self._persons_punchs_data.get(person, [])
+        for moment_rope, day_punch_paths in moments.items():
+            if str(moment_rope) == moment_label:
+                combined = []
+                for path in day_punch_paths:
+                    try:
+                        combined.append(open_file(path))
+                    except Exception as exc:
+                        combined.append(f"[Error reading {path}: {exc}]")
+                self._set_punch_text("\n\n".join(combined))
+                return
+
+    def _set_punch_text(self, text: str):
+        self._punch_text.configure(state="normal")
+        self._punch_text.delete("1.0", tk_END)
+        if text:
+            self._punch_text.insert("1.0", text)
+        self._punch_text.configure(state="disabled")
+
+    def _copy_punch_text(self):
+        if text := self._punch_text.get("1.0", tk_END).strip():
+            self.clipboard_clear()
+            self.clipboard_append(text)
+            self._copy_btn.configure(text="✔  Copied!")
+            self.after(1500, lambda: self._copy_btn.configure(text="⧉  Copy"))
 
     @staticmethod
     def _placeholder(entry, var, tip):
@@ -537,10 +743,8 @@ class ETLApp(tk_Tk):
             beliefs_src_dir=self._b_src_dir.get(),
         )
         self._status.set("✔  Pipeline completed successfully.")
-        for person_name, moment_day_punch_paths in persons_punchs.items():
-            for moment_rope, day_punch_paths in moment_day_punch_paths:
-                for day_punch_path in day_punch_paths:
-                    punch_str = open_file(day_punch_path)
+        print("create_today_punchs complete")
+        self._populate_viewer(persons_punchs)
         prettify_excel_files(self._b_src_dir.get())
         prettify_excel_files(self._i_src_dir.get())
         tkinter_messagebox.showinfo("Done", "ETL pipeline finished successfully.")


### PR DESCRIPTION
## Summary by Sourcery

Add punch file viewing capabilities to the ETL GUI and expose punch file paths from the world/calendar pipeline for use by the UI.

New Features:
- Introduce a punch viewer panel in the ETL GUI that lets users select a person and moment to view and copy generated punch file contents after a run.

Enhancements:
- Resize and restructure the ETL GUI into a two‑column layout with a persistent status bar and an enlarged, resizable main window.
- Update the ETL pipeline entry point to return per‑person punch file paths grouped by moment, and have the GUI run handler populate the viewer from this data.
- Slightly simplify schedule string generation in the Google Calendar utilities and improve SQL string formatting in tests for readability.

Tests:
- Extend world and KPI tests to validate the new punch path mappings returned from punch generation and copy helpers, and update existing tests to match the reformatted SQL strings.