### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Set version from tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Set version from tag
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Set version from tag
         run: |

--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Install Dependencies
         run: |

--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Install Dependencies
         run: |

--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Install Dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Repository: https://github.com/jschalk/keg
 
 ## Requirements
 
-- **Python 3.11+** — [download here](https://www.python.org/downloads/)
+- **Python 3.12+** — [download here](https://www.python.org/downloads/)
 
 ---
 
 ## Installation
 
-1. Install Python 3.11 or newer from the link above
+1. Install Python 3.12 or newer from the link above
 2. Open Command Prompt and run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Repository: https://github.com/jschalk/keg
 
 ## Requirements
 
-- **Python 3.14** — [download here](https://www.python.org/downloads/)
+- **Python 3.10+** — [download here](https://www.python.org/downloads/)
 
 ---
 
 ## Installation
 
-1. Install Python 3.14 from the link above
+1. Install Python 3.10 or newer from the link above
 2. Open Command Prompt and run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Repository: https://github.com/jschalk/keg
 
 ## Requirements
 
-- **Python 3.10+** — [download here](https://www.python.org/downloads/)
+- **Python 3.11+** — [download here](https://www.python.org/downloads/)
 
 ---
 
 ## Installation
 
-1. Install Python 3.10 or newer from the link above
+1. Install Python 3.11 or newer from the link above
 2. Open Command Prompt and run:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ description = "A Python package for communicating across cultures."
 license = {text = "MIT"}
 name = "keg2"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 version = "0.83.11"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ description = "A Python package for communicating across cultures."
 license = {text = "MIT"}
 name = "keg2"
 readme = "README.md"
-requires-python = ">=3.11"
-version = "0.83.11"
+requires-python = ">=3.12"
+version = "0.83.12"
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ description = "A Python package for communicating across cultures."
 license = {text = "MIT"}
 name = "keg2"
 readme = "README.md"
-requires-python = ">=3.14"
+requires-python = ">=3.10"
 version = "0.83.11"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Update supported Python version to 3.12+ across project configuration, documentation, and release workflow.

Build:
- Relax minimum Python requirement in pyproject to 3.12 and bump package version to 0.83.12.

CI:
- Update GitHub Actions publish workflow to run on Python 3.12.

Documentation:
- Adjust README to state Python 3.12+ as the required version and update installation instructions accordingly.