### PR TITLE
1079 build relative timezone tools2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Set version from tag
         run: |

--- a/.github/workflows/run-tests-on-push.yml
+++ b/.github/workflows/run-tests-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
           architecture: 'x64'
       - name: Install Dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Repository: https://github.com/jschalk/keg
 
 ## Requirements
 
-- **Python 3.12+** — [download here](https://www.python.org/downloads/)
+- **Python 3.11+** — [download here](https://www.python.org/downloads/)
 
 ---
 
 ## Installation
 
-1. Install Python 3.12 or newer from the link above
+1. Install Python 3.11 or newer from the link above
 2. Open Command Prompt and run:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ description = "A Python package for communicating across cultures."
 license = {text = "MIT"}
 name = "keg2"
 readme = "README.md"
-requires-python = ">=3.12"
-version = "0.83.12"
+requires-python = ">=3.11"
+version = "0.83.11"
 
 [project.optional-dependencies]
 test = [

--- a/src/ch04_rope/test/test_rope_core.py
+++ b/src/ch04_rope/test/test_rope_core.py
@@ -264,7 +264,7 @@ def test_rope_get_tail_label_ReturnsLabelTermWhenNonDefaultknot():
     # ESTABLISH
     bloomers_str = "bloomers"
     tulips_str = "tulips"
-    slash_casa_rope = f"{exx.slash}{"YY"}{exx.slash}{exx.casa}{exx.slash}"
+    slash_casa_rope = f"{exx.slash}YY{exx.slash}{exx.casa}{exx.slash}"
     slash_bloomers_rope = f"{slash_casa_rope}{bloomers_str}{exx.slash}"
     slash_tulips_rope = f"{slash_bloomers_rope}{tulips_str}{exx.slash}"
 
@@ -292,7 +292,7 @@ def test_rope_get_first_label_from_rope_ReturnsLabelTerm():
 def test_rope_get_parent_rope_ReturnsObj_Scenario0():
     # ESTABLISH
     x_s = default_knot_if_None()
-    expected_root_rope = f"{x_s}{"YY"}{x_s}"
+    expected_root_rope = f"{x_s}YY{x_s}"
     casa_rope = f"{expected_root_rope}{exx.casa}{x_s}"
     bloomers_str = "bloomers"
     bloomers_rope = f"{casa_rope}{bloomers_str}{x_s}"
@@ -309,7 +309,7 @@ def test_rope_get_parent_rope_ReturnsObj_Scenario0():
 def test_rope_get_parent_rope_ReturnsObj_Scenario1():
     # ESTABLISH
     x_s = "/"
-    expected_root_rope = f"{x_s}{"YY"}{x_s}"
+    expected_root_rope = f"{x_s}YY{x_s}"
     casa_rope = f"{expected_root_rope}{exx.casa}{x_s}"
     bloomers_str = "bloomers"
     bloomers_rope = f"{casa_rope}{bloomers_str}{x_s}"

--- a/src/ch13_time/epoch_str_func.py
+++ b/src/ch13_time/epoch_str_func.py
@@ -30,7 +30,8 @@ def get_reason_case_readable_str(
             if week_lower_bool and week_upper_bool:
                 return f"case: every {weekday_plan.plan_label}"
 
-    x_str = f"case: {caseunit.reason_state.replace(reason_context, "", 1)}"
+    emtpy_str = ""
+    x_str = f"case: {caseunit.reason_state.replace(reason_context, emtpy_str, 1)}"
     if caseunit.reason_divisor:
         x_str += f" divided by {caseunit.reason_divisor} then"
     if caseunit.reason_lower is not None and caseunit.reason_upper is not None:

--- a/src/ch17_brick/test/test_brick_db_tool/test_brick_intake_validation.py
+++ b/src/ch17_brick/test/test_brick_db_tool/test_brick_intake_validation.py
@@ -7,8 +7,10 @@ def test_is_column_type_valid_ReturnsObj():
     # ESTABLISH
     sue_bob_df = DataFrame({"Per": ["Sue", "Bob"]})
     per_dtype = sue_bob_df["Per"].dropna().infer_objects().dtype
-    print(f"{per_dtype=} {"object"==per_dtype=}")
-    print(f"{str(per_dtype)=} {"str"==str(per_dtype)=}")
+    is_object_dtype = per_dtype == "object"
+    is_str_dtype = str(per_dtype) == "str"
+    print(f"{per_dtype=} {is_object_dtype=}")
+    print(f"{str(per_dtype)=} {is_str_dtype=}")
 
     # WHEN / THEN
     assert is_column_type_valid(DataFrame({"ID": [1, 2, 3]}), "ID", "INT")

--- a/src/linter/test/migration_tools/test_find_replace.py
+++ b/src/linter/test/migration_tools/test_find_replace.py
@@ -61,7 +61,7 @@ from tempfile import TemporaryDirectory as tempfile_TemporaryDirectory
 
 
 def test_replace_in_tracked_python_files():
-    with tempfile_TemporaryDirectory(delete=False) as tmpdir:
+    with tempfile_TemporaryDirectory() as tmpdir:
         os_chdir(tmpdir)
 
         # Initialize a temporary git repo


### PR DESCRIPTION
## Summary by Sourcery

Adjust project Python version requirements and minor utilities while simplifying some test helpers and string handling.

Bug Fixes:
- Fix invalid f-string expressions in rope and brick tests by simplifying embedded literals.
- Correct reason string construction in epoch_str_func by using an explicit empty replacement string.
- Avoid leaking temporary directories in migration tools tests by relying on default deletion behavior.

Build:
- Lower required Python version in project metadata from 3.12 to 3.11.

CI:
- Update GitHub Actions workflows to run against Python 3.11 instead of 3.12.

Documentation:
- Update README requirements and installation instructions to reference Python 3.11 instead of 3.12.

Tests:
- Clean up brick intake validation test debug output to use precomputed boolean flags for dtype checks.
- Fix rope core tests string construction for expected ropes and root paths.