### PR TITLE
remove all reference of current working directory where possible

### DIFF
--- a/src/ch07_person_logic/person_config.py
+++ b/src/ch07_person_logic/person_config.py
@@ -1,5 +1,4 @@
 from ch00_py.file_toolbox import create_path, open_json
-from os import getcwd as os_getcwd
 
 
 def max_tree_traverse_default() -> int:
@@ -8,8 +7,7 @@ def max_tree_traverse_default() -> int:
 
 def person_config_path() -> str:
     """src/ch07_person_logic/person_config.json"""
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch07_person_logic")
+    chapter_dir = create_path("src", "ch07_person_logic")
     return create_path(chapter_dir, "person_config.json")
 
 

--- a/src/ch07_person_logic/test/test_person/test__person_config.py
+++ b/src/ch07_person_logic/test/test_person/test__person_config.py
@@ -12,7 +12,6 @@ from ch07_person_logic.person_config import (
 )
 from ch07_person_logic.person_main import ContactUnit, PersonUnit
 from ch99_glossary.ch_keyword import Ch07Keywords as kw
-from os import getcwd as os_getcwd
 from os.path import exists as os_path_exists
 
 
@@ -23,8 +22,7 @@ def test_max_tree_traverse_default_ReturnsObj() -> str:
 
 def test_get_person_config_dict_Exists():
     # ESTABLISH
-    src_dir = create_path(os_getcwd(), "src")
-    expected_dir = create_path(src_dir, "ch07_person_logic")
+    expected_dir = create_path("src", "ch07_person_logic")
 
     # WHEN
     config_path = person_config_path()

--- a/src/ch08_person_atom/atom_config.py
+++ b/src/ch08_person_atom/atom_config.py
@@ -1,13 +1,11 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json, save_json
 from ch08_person_atom._ref.ch08_semantic_types import CRUD_command
-from os import getcwd as os_getcwd
 
 
 def atom_config_path() -> str:
     "Returns Path: ch08_person_atom/atom_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch08_person_atom")
+    chapter_dir = create_path("src", "ch08_person_atom")
     return create_path(chapter_dir, "atom_config.json")
 
 

--- a/src/ch13_time/epoch_main.py
+++ b/src/ch13_time/epoch_main.py
@@ -17,7 +17,6 @@ from ch13_time._ref.ch13_semantic_types import (
 )
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from os import getcwd as os_getcwd
 from re import search as re_search
 from typing import Tuple
 
@@ -170,9 +169,7 @@ def get_epoch_length(epoch_config: dict) -> int:
 
 def epoch_config_path() -> str:
     "Returns path: src/ch13_time/epoch_configs/default_epoch_config.json"
-
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch13_time")
+    chapter_dir = create_path("src", "ch13_time")
     epoch_configs_dir = create_path(chapter_dir, "epoch_configs")
     return create_path(epoch_configs_dir, "default_epoch_config.json")
 

--- a/src/ch14_moment/moment_config.py
+++ b/src/ch14_moment/moment_config.py
@@ -1,12 +1,10 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
-from os import getcwd as os_getcwd
 
 
 def moment_config_path() -> str:
     "Returns Path: a15_moment_logic/moment_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch14_moment")
+    chapter_dir = create_path("src", "ch14_moment")
     return create_path(chapter_dir, "moment_config.json")
 
 

--- a/src/ch14_moment/test/test_moment_config/test_moment_config_.py
+++ b/src/ch14_moment/test/test_moment_config/test_moment_config_.py
@@ -9,13 +9,11 @@ from ch14_moment.moment_config import (
     moment_config_path,
 )
 from ch99_glossary.ch_keyword import Ch14Keywords as kw, ExampleStrs as exx
-from os import getcwd as os_getcwd
 
 
 def test_moment_config_path_ReturnsObj_Moment() -> str:
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch14_moment")
+    chapter_dir = create_path("src", "ch14_moment")
     assert moment_config_path() == create_path(chapter_dir, "moment_config.json")
 
 

--- a/src/ch15_nabu/nabu_config.py
+++ b/src/ch15_nabu/nabu_config.py
@@ -1,12 +1,10 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
-from os import getcwd as os_getcwd
 
 
 def nabu_config_path():
     "Returns path: c15_nabu/nabu_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch15_nabu")
+    chapter_dir = create_path("src", "ch15_nabu")
     return create_path(chapter_dir, "nabu_config.json")
 
 

--- a/src/ch15_nabu/test/test_nabu_config.py
+++ b/src/ch15_nabu/test/test_nabu_config.py
@@ -10,13 +10,11 @@ from ch15_nabu.nabu_config import (
     set_nabuable_otx_inx_args,
 )
 from ch99_glossary.ch_keyword import Ch15Keywords as kw
-from os import getcwd as os_getcwd
 
 
 def test_nabu_config_path_ReturnsObj_Nabu() -> str:
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch15_nabu")
+    chapter_dir = create_path("src", "ch15_nabu")
     assert nabu_config_path() == create_path(chapter_dir, "nabu_config.json")
 
 

--- a/src/ch16_translate/test/test__translate_config/test_translate_config_.py
+++ b/src/ch16_translate/test/test__translate_config/test_translate_config_.py
@@ -10,7 +10,6 @@ from ch16_translate.translate_config import (
     translate_config_path,
 )
 from ch99_glossary.ch_keyword import Ch16Keywords as kw
-from os import getcwd as os_getcwd
 
 
 def test_get_translate_filename_ReturnsObj():
@@ -20,8 +19,7 @@ def test_get_translate_filename_ReturnsObj():
 
 def test_translate_config_path_ReturnsObj_Translate() -> str:
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch16_translate")
+    chapter_dir = create_path("src", "ch16_translate")
     assert translate_config_path() == create_path(chapter_dir, "translate_config.json")
 
 

--- a/src/ch16_translate/translate_config.py
+++ b/src/ch16_translate/translate_config.py
@@ -1,13 +1,11 @@
 from ch00_py.dict_toolbox import get_from_nested_dict
 from ch00_py.file_toolbox import create_path, open_json
 from ch08_person_atom.atom_config import get_all_person_dimen_delete_keys
-from os import getcwd as os_getcwd
 
 
 def translate_config_path() -> str:
     "Returns path: c16_translate/translate_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch16_translate")
+    chapter_dir = create_path("src", "ch16_translate")
     return create_path(chapter_dir, "translate_config.json")
 
 

--- a/src/ch17_brick/_ref/ch17_path.py
+++ b/src/ch17_brick/_ref/ch17_path.py
@@ -1,9 +1,7 @@
 from ch00_py.file_toolbox import create_path
-from os import getcwd as os_getcwd
 
 
 def get_excel_reader_config_path() -> str:
     "Returns path: ch17_brick/excel_reader.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch17_brick")
+    chapter_dir = create_path("src", "ch17_brick")
     return create_path(chapter_dir, "excel_reader.json")

--- a/src/ch17_brick/brick_config.py
+++ b/src/ch17_brick/brick_config.py
@@ -2,13 +2,11 @@ from ch00_py.db_toolbox import get_sorted_cols_only_list
 from ch00_py.file_toolbox import create_path, get_json_filename, open_json
 from ch99_glossary.sorter import get_keg_elements_sort_order
 from enum import Enum
-from os import getcwd as os_getcwd
 
 
 def brick_config_path() -> str:
     "Returns path: ch17_brick/brick_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch17_brick")
+    chapter_dir = create_path("src", "ch17_brick")
     return create_path(chapter_dir, "brick_config.json")
 
 

--- a/src/ch17_brick/test/test_brick_/test__brick_config.py
+++ b/src/ch17_brick/test/test_brick_/test__brick_config.py
@@ -45,7 +45,6 @@ from ch17_brick.brick_config import (
 from ch99_glossary.ch_keyword import Ch17Keywords as kw
 from ch99_glossary.sorter import get_keg_elements_sort_order
 from copy import copy as copy_copy
-from os import getcwd as os_getcwd
 
 
 def test_get_keg_elements_sort_order_ReturnsObj():
@@ -572,8 +571,7 @@ def test_get_allowed_curds_ReturnsObj():
 
 def test_brick_config_path_ReturnsObj_Brick() -> str:
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch17_brick")
+    chapter_dir = create_path("src", "ch17_brick")
     assert brick_config_path() == create_path(chapter_dir, "brick_config.json")
 
 

--- a/src/ch17_brick/test/test_brick_db_tool/test__brick_from_file.py
+++ b/src/ch17_brick/test/test_brick_db_tool/test__brick_from_file.py
@@ -7,15 +7,12 @@ from ch17_brick.brick_db_tool import (
     get_excel_reader_src_config,
 )
 from ch99_glossary.ch_keyword import Ch17Keywords as kw
-from json import dump as json_dump
 from openpyxl import Workbook
-from os import getcwd as os_getcwd
 
 
 def test_get_excel_reader_config_path_ReturnsObj() -> str:
     # ESTABLISH
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch17_brick")
+    chapter_dir = create_path("src", "ch17_brick")
     # WHEN / THEN
     assert get_excel_reader_config_path() == create_path(
         chapter_dir, "excel_reader.json"

--- a/src/ch18_etl_config/etl_config.py
+++ b/src/ch18_etl_config/etl_config.py
@@ -10,7 +10,6 @@ from ch17_brick.brick_config import (
     get_default_sorted_list,
 )
 from copy import copy as copy_copy
-from os import getcwd as os_getcwd
 
 ALL_DIMEN_ABBV7 = {
     "MMTPAYY",
@@ -173,8 +172,7 @@ def create_prime_tablename(
 
 def etl_stage_types_config_path() -> str:
     "Returns path: ch18_etl_config/etl_stage_types_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch18_etl_config")
+    chapter_dir = create_path("src", "ch18_etl_config")
     return create_path(chapter_dir, "etl_stage_types_config.json")
 
 
@@ -194,8 +192,7 @@ def get_ordered_stage_types() -> list[str]:
 
 def etl_brick_category_config_path() -> str:
     "Returns path: ch18_etl_config/etl_brick_category_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch18_etl_config")
+    chapter_dir = create_path("src", "ch18_etl_config")
     return create_path(chapter_dir, "etl_brick_category_config.json")
 
 

--- a/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
+++ b/src/ch18_etl_config/test/etl_sqlstrs/test__etl_table.py
@@ -23,7 +23,6 @@ from ch18_etl_config.etl_config import (
     remove_staging_columns,
 )
 from ch99_glossary.ch_keyword import Ch18Keywords as kw
-from os import getcwd as os_getcwd
 
 
 def test_remove_otx_columns_ReturnsObj():
@@ -204,8 +203,7 @@ def test_get_all_dimen_columns_set_ReturnsObj_Scenario1_translate_core_Dimens():
 
 def test_etl_stage_types_config_path_ReturnsObj():
     # ESTABLISH
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch18_etl_config")
+    chapter_dir = create_path("src", "ch18_etl_config")
     # WHEN / THEN
     assert etl_stage_types_config_path() == create_path(
         chapter_dir, "etl_stage_types_config.json"
@@ -298,8 +296,7 @@ def test_get_ordered_stage_types_ReturnsObj():
 
 def test_etl_brick_category_config_path_ReturnsObj():
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch18_etl_config")
+    chapter_dir = create_path("src", "ch18_etl_config")
     assert etl_brick_category_config_path() == create_path(
         chapter_dir, "etl_brick_category_config.json"
     )

--- a/src/ch19_idea_src/idea_config.py
+++ b/src/ch19_idea_src/idea_config.py
@@ -1,14 +1,9 @@
-from ch00_py.db_toolbox import get_sorted_cols_only_list
-from ch00_py.file_toolbox import create_path, get_json_filename, open_json
-from ch99_glossary.sorter import get_keg_elements_sort_order
-from enum import Enum
-from os import getcwd as os_getcwd
+from ch00_py.file_toolbox import create_path, open_json
 
 
 def idea_config_path() -> str:
     "Returns path: ch19_idea_src/idea_config.json"
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch19_idea_src")
+    chapter_dir = create_path("src", "ch19_idea_src")
     return create_path(chapter_dir, "idea_config.json")
 
 

--- a/src/ch19_idea_src/test/idea2brick/test_idea_config.py
+++ b/src/ch19_idea_src/test/idea2brick/test_idea_config.py
@@ -9,13 +9,11 @@ from ch19_idea_src.idea_config import (
     is_non_mirror,
 )
 from ch99_glossary.ch_keyword import Ch19Keywords as kw
-from os import getcwd as os_getcwd
 
 
 def test_idea_config_path_ReturnsObj_Brick() -> str:
     # ESTABLISH / WHEN / THEN
-    src_dir = create_path(os_getcwd(), "src")
-    chapter_dir = create_path(src_dir, "ch19_idea_src")
+    chapter_dir = create_path("src", "ch19_idea_src")
     assert idea_config_path() == create_path(chapter_dir, "idea_config.json")
 
 

--- a/src/ch98_linter/ch_move.py
+++ b/src/ch98_linter/ch_move.py
@@ -16,7 +16,6 @@ from os.path import isdir as os_path_isdir
 
 
 def ch_move_main():
-    src_dir = create_path(os_getcwd(), "src")
     src_chxx_str = input("Chapter to move (int): ").strip()
     dst_chxx_str = input("Chapter destina (int): ").strip()
     src_chxx_int = int(src_chxx_str)
@@ -28,30 +27,30 @@ def ch_move_main():
     print(f"Goal is to move {src_chxx_prefix} to {dst_chxx_prefix}")
 
     # Sanity checks
-    dst_chxx_dir_prefix = create_path(src_dir, dst_chxx_prefix)
+    dst_chxx_dir_prefix = create_path("src", dst_chxx_prefix)
     x_prefix_dir = ""
     for prefix_dir in first_level_dirs_with_prefix(dst_chxx_dir_prefix):
         print(f"Try to delete {prefix_dir}")
         delete_if_empty_or_pycache_only(prefix_dir)
 
-    if not os_path_isdir(src_dir):
+    if not os_path_isdir("src"):
         print("Error: directory does not exist.")
         return
 
-    if string_exists_in_filepaths(src_dir, dst_chxx_prefix):
+    if string_exists_in_filepaths("src", dst_chxx_prefix):
         print(f"❌ The new string '{dst_chxx_prefix}' already exists in file paths.")
         return
 
-    if string_exists_in_directory(src_dir, dst_chxx_prefix):
+    if string_exists_in_directory("src", dst_chxx_prefix):
         print(f"❌ The new string '{dst_chxx_prefix}' already exists in file contents.")
         return
 
     # file contents
-    change_ref_json(src_dir, src_chxx_prefix, x_prefix_dir, dst_chxx_int)
+    change_ref_json("src", src_chxx_prefix, x_prefix_dir, dst_chxx_int)
     replace_in_tracked_python_files(src_chxx_prefix, replace_text=dst_chxx_prefix)
     replace_in_tracked_python_files(src_uppercase_chxx, dst_uppercase_chxx)
     # change file paths
-    rename_files_and_dirs_4times(src_dir, src_chxx_prefix, dst_chxx_prefix)
+    rename_files_and_dirs_4times("src", src_chxx_prefix, dst_chxx_prefix)
     print("✅ Replacement complete.")
 
 

--- a/src/ch98_linter/create_notebook.py
+++ b/src/ch98_linter/create_notebook.py
@@ -11,15 +11,8 @@
 # save_marimo_notebook_from_test_file(test_file_path, test_name, dest_file_path)
 
 
-from ch00_py.file_toolbox import create_path, open_json, save_json
+from ch00_py.file_toolbox import create_path
 from ch00_py.notebook_toolbox import save_marimo_notebook_from_test_file
-from ch98_linter.chapter_move_tool import (
-    first_level_dirs_with_prefix,
-    rename_files_and_dirs_4times,
-    string_exists_in_filepaths,
-)
-from os import getcwd as os_getcwd
-from os.path import isdir as os_path_isdir
 
 # HOW TO USE:
 # Open up CMD, change directory to repo

--- a/src/ch98_linter/paths_change.py
+++ b/src/ch98_linter/paths_change.py
@@ -16,14 +16,3 @@ def paths_change_main():
     if os_path_isdir(src_dir) is False:
         print("Error: directory does not exist.")
         return
-
-    # if string_exists_in_filepaths(src_dir, replace_str):
-    #     print(f"❌ The new string '{replace_str}' already exists in file paths.")
-    #     return
-
-    rename_files_and_dirs_4times(src_dir, find_str, replace_str)
-    print("✅ Replacement complete.")
-
-
-if __name__ == "__main__":
-    paths_change_main()


### PR DESCRIPTION
## Summary by Sourcery

Standardize path handling by removing reliance on the current working directory and simplifying chapter config paths and related tooling.

Enhancements:
- Update chapter configuration and helper functions to build paths from the fixed "src" root instead of using the current working directory.
- Align tests with the new path construction logic based on the "src" root directory.
- Simplify the chapter-move and path-change utilities to avoid deriving src paths from the current working directory and remove dead code and unused imports.

Chores:
- Remove now-unused imports related to current working directory handling and JSON utilities across affected modules.