### PR TITLE
fix: #1228 load idea_config.json from package location instead of ass…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,8 @@ version_variable = "keg/__init__.py:__version__"
 package-dir = {"" = "src"}
 py-modules = ["listen"]
 
+[tool.setuptools.package-data]
+ch19_idea_src = ["idea_config.json"]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/ch19_idea_src/idea_config.py
+++ b/src/ch19_idea_src/idea_config.py
@@ -1,10 +1,26 @@
-from ch00_py.file_toolbox import create_path, open_json
+from ch00_py.file_toolbox import open_json
+from importlib.resources import as_file, files
+from pathlib import Path
 
 
 def idea_config_path() -> str:
     "Returns path: ch19_idea_src/idea_config.json"
-    chapter_dir = create_path("src", "ch19_idea_src")
-    return create_path(chapter_dir, "idea_config.json")
+    module_dir = Path(__file__).resolve().parent
+    candidate_path = module_dir / "idea_config.json"
+    if candidate_path.exists():
+        return str(candidate_path)
+
+    try:
+        resource = files(__package__) / "idea_config.json"
+        with as_file(resource) as resource_path:
+            if resource_path.exists():
+                return str(resource_path)
+    except Exception:
+        pass
+
+    raise FileNotFoundError(
+        f"Missing idea_config.json from package resources or module path: {candidate_path}"
+    )
 
 
 def get_idea_config_dict() -> dict:

--- a/src/ch19_idea_src/test/idea2brick/test_idea_config.py
+++ b/src/ch19_idea_src/test/idea2brick/test_idea_config.py
@@ -9,12 +9,14 @@ from ch19_idea_src.idea_config import (
     is_non_mirror,
 )
 from ch99_glossary.ch_keyword import Ch19Keywords as kw
+from pathlib import Path
 
 
 def test_idea_config_path_ReturnsObj_Brick() -> str:
     # ESTABLISH / WHEN / THEN
-    chapter_dir = create_path("src", "ch19_idea_src")
-    assert idea_config_path() == create_path(chapter_dir, "idea_config.json")
+    path_str = idea_config_path()
+    assert path_str.endswith("idea_config.json")
+    assert Path(path_str).is_file()
 
 
 def test_get_idea_config_dict_ReturnsObj_Scenario0_AllBrickTypesRepresented():


### PR DESCRIPTION
…uming current working directory

## Summary by Sourcery

Load idea_config.json from the ch19_idea_src package resources or module directory instead of assuming the current working directory.

Bug Fixes:
- Ensure idea_config.json is resolved relative to the module/package location, avoiding failures when the working directory differs.

Enhancements:
- Relax the idea_config_path test to assert existence of idea_config.json rather than a hard-coded path.
- Include idea_config.json as package data via setuptools configuration so it is available when installed.

Build:
- Configure setuptools package-data to include idea_config.json in the ch19_idea_src package.

Tests:
- Update idea_config_path test to verify that idea_config.json exists on disk without depending on a specific filesystem layout.